### PR TITLE
WEB-3728 : Add Filter : Don't keep past events endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.0.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WEB-3728 : Add Filter : Don't keep past events endpoint
+  [boulch]
 
 
 1.0.13 (2022-07-14)
@@ -22,7 +23,7 @@ Changelog
 
 - [WEB-3674]Fix itinerary links
   [remdub]
-  
+
 - [WEB-3661]Set b_size to 100 on search results
   [remdub]
 


### PR DESCRIPTION
My dear @laulaz ,

This is an old needed feature.

https://support.imio.be/browse/WEB-3728?filter=-1

What do you think about that?
If events recurrence change some things about that... I think there will be time to change that in due time.