### PR TITLE
SUP-30074 : Fix broken RelationValue "AttributeError: 'NoneType' object has no attribute 'UID'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.1.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- SUP-30074 : Fix broken RelationValue "AttributeError: 'NoneType' object has no attribute 'UID'
+  [boulch]
 
 
 1.1.14 (2023-04-25)

--- a/src/imio/smartweb/core/contents/folder/views.py
+++ b/src/imio/smartweb/core/contents/folder/views.py
@@ -67,7 +67,9 @@ class FolderView(BaseFolderView):
         if self.context.quick_access_items is None:
             return {"results": results, "quick_access": []}
         quick_access_uids = [
-            item.to_object.UID() for item in self.context.quick_access_items
+            item.to_object.UID()
+            for item in self.context.quick_access_items
+            if item.isBroken() is False
         ]
         quick_access_brains = api.content.find(
             UID=quick_access_uids,


### PR DESCRIPTION
@laulaz  
Do we just ignore this item thanks to "isBroken" condition or should I be more severe and remove it from the field at this time?