### PR TITLE
WEB-3999 : Keep order of contacts in its view through manualy sorted related_contacts in edit form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.1.30 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WEB-3999 : Keep order of contacts in its view through manualy sorted related_contacts in edit form
+  [boulch]
 
 
 1.1.29 (2023-10-18)

--- a/src/imio/smartweb/core/contents/sections/contact/content.py
+++ b/src/imio/smartweb/core/contents/sections/contact/content.py
@@ -3,7 +3,7 @@
 from imio.smartweb.core.contents.sections.base import ISection
 from imio.smartweb.core.contents.sections.base import Section
 from imio.smartweb.locales import SmartwebMessageFactory as _
-from plone.app.z3cform.widget import SelectFieldWidget
+from plone.app.z3cform.widget import AjaxSelectFieldWidget
 from plone.autoform import directives
 from plone.supermodel import model
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
@@ -14,14 +14,18 @@ from zope.interface import implementer
 class ISectionContact(ISection):
     """Marker interface and Dexterity Python Schema for SectionContact"""
 
-    directives.widget(related_contacts=SelectFieldWidget)
+    directives.widget(
+        "related_contacts",
+        AjaxSelectFieldWidget,
+        source="imio.smartweb.vocabulary.RemoteContacts",
+    )
     related_contacts = schema.List(
         title=_("Related contacts"),
         description=_(
             "Select contacts. If you can't find contacts you want, make sure "
             """it exists in the directory and that its "state" is published."""
         ),
-        value_type=schema.Choice(vocabulary="imio.smartweb.vocabulary.RemoteContacts"),
+        value_type=schema.Choice(source="imio.smartweb.vocabulary.RemoteContacts"),
         required=True,
     )
 

--- a/src/imio/smartweb/core/contents/sections/contact/view.py
+++ b/src/imio/smartweb/core/contents/sections/contact/view.py
@@ -14,7 +14,8 @@ class ContactView(HashableJsonSectionView):
     def contacts(self):
         if self.context.related_contacts is None:
             return
-        uids = "&UID=".join(self.context.related_contacts)
+        related_contacts = self.context.related_contacts
+        uids = "&UID=".join(related_contacts)
         url = "{}/@search?UID={}&fullobjects=1".format(DIRECTORY_URL, uids)
         current_lang = api.portal.get_current_language()[:2]
         if current_lang != "fr":
@@ -23,9 +24,10 @@ class ContactView(HashableJsonSectionView):
         self.refresh_modification_date()
         if self.json_data is None or len(self.json_data.get("items", [])) == 0:  # NOQA
             return
-        return batch_results(
-            self.json_data.get("items"), self.context.nb_contact_by_line
-        )
+        results = self.json_data.get("items")
+        index_map = {value: index for index, value in enumerate(related_contacts)}
+        results = sorted(results, key=lambda x: index_map[x["UID"]])
+        return batch_results(results, self.context.nb_contact_by_line)
 
     def get_contact_properties(self, json_dict):
         return ContactProperties(json_dict)


### PR DESCRIPTION
@laulaz 

Please, could you review this PR ? 
Look at that, it’s tested too !!