### PR TITLE
WEB-3992 : Fix invisible icons (no fill attributes or fill="none")

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2.21 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- WEB-3992 : Fix invisible icons (no fill attributes or fill="none")
+  [boulch]
 
 
 1.2.20 (2023-12-07)

--- a/src/imio/smartweb/core/browser/icons.py
+++ b/src/imio/smartweb/core/browser/icons.py
@@ -31,7 +31,9 @@ class SmartwebIconsView(IconsView):
 
     def tag(self, name, tag_class="", tag_alt=""):
         try:
-            return super(SmartwebIconsView, self).tag(name, tag_class, tag_alt)
+            svg_bstr = super(SmartwebIconsView, self).tag(name, tag_class, tag_alt)
+            svg_bstr = self.ensure_fill_in_svg_tags(svg_bstr)
+            return svg_bstr
         except NotImplementedError:
             # Resolving icon stored in database, let's do it below
             # See https://github.com/plone/Products.CMFPlone/pull/3359
@@ -56,4 +58,11 @@ class SmartwebIconsView(IconsView):
         for name, modifier in SVG_MODIFER.items():
             __traceback_info__ = name
             modifier(svgtree, modifier_cfg)
-        return etree.tostring(svgtree)
+        return self.ensure_fill_in_svg_tags(etree.tostring(svgtree))
+
+    def ensure_fill_in_svg_tags(self, svg_bstr):
+        original_string = svg_bstr.decode("utf-8")
+        if "fill=" not in original_string or 'fill="none"' in original_string:
+            modified_string = original_string.replace("<svg", '<svg fill="#000000"')
+            svg_bstr = modified_string.encode("utf-8")
+        return svg_bstr


### PR DESCRIPTION
@laulaz 

I think, next step would be having a "global" configuration field in smartweb settings : "color for icons" and instead of set a hard coded default black color for icons 

`modified_string = original_string.replace("<svg", '<svg fill="#000000"')`

we could get it from plone registry (with black as default value

I can make some tests but I can only test if "fill" is really in svg tag... I don't know how I can test that icon really appear (robot?)