### PR TITLE
fix: use pat-contentbrowser instead of pat-relateditems for links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Changelog
   [boulch]
 - WEB-4256 : Use pat-contentbrowser instead of pat-relateditems for links
   [remdub]
+- Fix bad catalog query when we get contacts from directory
+  [boulch]
 
 - WEB-4252 : Increase timeout for section events
   [boulch]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.4.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- WEB-4256 : Use pat-contentbrowser instead of pat-relateditems for
+  links, quickaccess collectionssection, eventssection and newssection
+  [remdub]
 
 
 1.4.6 (2025-06-26)
@@ -36,8 +38,7 @@ Changelog
 
 - Fix bad catalog query when we get contacts from directory
   [boulch]
-- WEB-4256 : Use pat-contentbrowser instead of pat-relateditems for links
-  [remdub]
+
 - Fix bad catalog query when we get contacts from directory
   [boulch]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ Changelog
 
 - Fix bad catalog query when we get contacts from directory
   [boulch]
+- WEB-4256 : Use pat-contentbrowser instead of pat-relateditems for links
+  [remdub]
 
 - WEB-4252 : Increase timeout for section events
   [boulch]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 ------------------
 
 - WEB-4256 : Use pat-contentbrowser instead of pat-relateditems for
-  links, quickaccess collectionssection, eventssection and newssection
+  Link, QuickAccess, SectionCollection, SectionEvents and SectionNews
   [remdub]
 
 
@@ -38,11 +38,6 @@ Changelog
 
 - Fix bad catalog query when we get contacts from directory
   [boulch]
-
-- Fix bad catalog query when we get contacts from directory
-  [boulch]
-- WEB-4256 : Use pat-contentbrowser instead of pat-relateditems for links
-  [remdub]
 
 - WEB-4252 : Increase timeout for section events
   [boulch]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Changelog
 
 - Fix bad catalog query when we get contacts from directory
   [boulch]
+- WEB-4256 : Use pat-contentbrowser instead of pat-relateditems for links
+  [remdub]
 
 - WEB-4252 : Increase timeout for section events
   [boulch]
@@ -69,7 +71,7 @@ Changelog
   [boulch]
 
 - WEB-4165 : Refactoring : Don't use react-helmet/react-helmet-async anymore to manage og tags in directory view
-  because of duplicated og:tags. Favor for creating og:tags in header viewlet (SSR) and update it thanks to REACT script  
+  because of duplicated og:tags. Favor for creating og:tags in header viewlet (SSR) and update it thanks to REACT script
   [boulch]
 
 - WEB-4165 : Add react-helmet pakcage (6.1.0) to manage og tags in directory view

--- a/src/imio/smartweb/core/behaviors/quickaccess.py
+++ b/src/imio/smartweb/core/behaviors/quickaccess.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from imio.smartweb.locales import SmartwebMessageFactory as _
-from plone.app.z3cform.widget import RelatedItemsFieldWidget
+from plone.app.z3cform.widgets.contentbrowser import ContentBrowserFieldWidget
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
@@ -22,7 +22,7 @@ class IQuickAccessSelection(model.Schema):
     )
     directives.widget(
         "quick_access_items",
-        RelatedItemsFieldWidget,
+        ContentBrowserFieldWidget,
         vocabulary="plone.app.vocabularies.Catalog",
         pattern_options={
             "favorites": [],

--- a/src/imio/smartweb/core/browser/templates/link_input.pt
+++ b/src/imio/smartweb/core/browser/templates/link_input.pt
@@ -11,8 +11,8 @@
         <div>
           <div class="mb-3 main">
             <!-- this gives the name to the "linkType" -->
-            <input type="text" name="internal" class="pat-relateditems"
-                    tal:attributes="data-pat-relateditems view/pattern_data;
+            <input type="text" name="internal" class="pat-contentbrowser"
+                    tal:attributes="data-pat-contentbrowser view/pattern_data;
                                     value value;
                                     name string:${view/name}.internal" />
           </div>

--- a/src/imio/smartweb/core/contents/sections/collection/content.py
+++ b/src/imio/smartweb/core/contents/sections/collection/content.py
@@ -3,7 +3,7 @@
 from imio.smartweb.core.contents.sections.base import ISection
 from imio.smartweb.core.contents.sections.base import Section
 from imio.smartweb.locales import SmartwebMessageFactory as _
-from plone.app.z3cform.widget import RelatedItemsFieldWidget
+from plone.app.z3cform.widgets.contentbrowser import ContentBrowserFieldWidget
 from plone.autoform import directives
 from plone.supermodel import model
 from z3c.relationfield.schema import RelationChoice
@@ -25,7 +25,7 @@ class ISectionCollection(ISection):
 
     directives.widget(
         "collection",
-        RelatedItemsFieldWidget,
+        ContentBrowserFieldWidget,
         vocabulary="plone.app.vocabularies.Catalog",
         pattern_options={
             "selectableTypes": ["Collection"],

--- a/src/imio/smartweb/core/contents/sections/events/content.py
+++ b/src/imio/smartweb/core/contents/sections/events/content.py
@@ -4,7 +4,7 @@ from imio.smartweb.common.widgets.select import TranslatedAjaxSelectWidget
 from imio.smartweb.core.contents.sections.base import ISection
 from imio.smartweb.core.contents.sections.base import Section
 from imio.smartweb.locales import SmartwebMessageFactory as _
-from plone.app.z3cform.widget import RelatedItemsFieldWidget
+from plone.app.z3cform.widgets.contentbrowser import ContentBrowserFieldWidget
 from plone.app.z3cform.widget import SelectFieldWidget
 from plone.autoform import directives
 from plone.supermodel import model
@@ -47,7 +47,7 @@ class ISectionEvents(ISection):
 
     directives.widget(
         "linking_rest_view",
-        RelatedItemsFieldWidget,
+        ContentBrowserFieldWidget,
         vocabulary="plone.app.vocabularies.Catalog",
         pattern_options={
             "selectableTypes": ["imio.smartweb.EventsView"],

--- a/src/imio/smartweb/core/contents/sections/news/content.py
+++ b/src/imio/smartweb/core/contents/sections/news/content.py
@@ -4,7 +4,7 @@ from imio.smartweb.common.widgets.select import TranslatedAjaxSelectWidget
 from imio.smartweb.core.contents.sections.base import ISection
 from imio.smartweb.core.contents.sections.base import Section
 from imio.smartweb.locales import SmartwebMessageFactory as _
-from plone.app.z3cform.widget import RelatedItemsFieldWidget
+from plone.app.z3cform.widgets.contentbrowser import ContentBrowserFieldWidget
 from plone.app.z3cform.widget import SelectFieldWidget
 from plone.autoform import directives
 from plone.supermodel import model
@@ -47,7 +47,7 @@ class ISectionNews(ISection):
 
     directives.widget(
         "linking_rest_view",
-        RelatedItemsFieldWidget,
+        ContentBrowserFieldWidget,
         vocabulary="plone.app.vocabularies.Catalog",
         pattern_options={
             "selectableTypes": ["imio.smartweb.NewsView"],


### PR DESCRIPTION
Plone 6.1 introduced the new pat-contentbrowser widget, replacing pat-relateditem. It is already set as the default for related items. To ensure consistent behavior, we have also set it as the default for links, quick access items, news sections, collection sections, and event sections.