### PR TITLE
WEB-4366 : Refactor caching with more spicialized endpoints to avoid …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Changelog
 
 - WEB-3495 : Improve minisite logo accessibility label
   [thomlamb]
+- WEB-4366 : Refactor caching with more specialized endpoints to avoid incorrect/random? entity/newsfolders retrieval from cache
+  [boulch]
 
 
 1.4.31 (2026-02-24)

--- a/src/imio/smartweb/core/tests/test_gdpr.py
+++ b/src/imio/smartweb/core/tests/test_gdpr.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+from imio.gdpr.browser.views import GDPRView as BaseGDPRView
+from imio.smartweb.core.browser.gdpr import GDPRView
+from imio.smartweb.core.testing import IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+from imio.smartweb.core.testing import ImioSmartwebTestCase
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+
+_GDPR_BASE_MODULE = "imio.gdpr.browser.views"
+
+
+class TestGDPRView(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def _make_view(self, context=None):
+        return GDPRView(context or self.portal, self.request)
+
+    # --- hide_herobanner ---
+
+    def test_hide_herobanner_is_true(self):
+        view = self._make_view()
+        self.assertTrue(view.hide_herobanner)
+
+    # --- __call__ ---
+
+    def test_call_delegates_to_parent(self):
+        view = self._make_view()
+        with patch.object(
+            BaseGDPRView, "__call__", return_value="parent_result"
+        ) as mock_call:
+            result = view()
+        mock_call.assert_called_once()
+        self.assertEqual(result, "parent_result")
+
+    def test_call_renders_index_when_no_gdpr_content_in_nav_root(self):
+        """When the nav root has no GDPR content, the base class renders the template."""
+        view = self._make_view()
+        view.index = MagicMock(return_value="<html>GDPR text</html>")
+        result = view()
+        view.index.assert_called_once()
+        self.assertEqual(result, "<html>GDPR text</html>")
+
+    def test_call_redirects_when_gdpr_content_exists_in_nav_root(self):
+        """When the nav root has a matching GDPR content object, the base class redirects."""
+        view = self._make_view()
+        expected_url = "http://localhost/gdpr-explanation"
+        mock_content = MagicMock()
+        mock_content.Language.return_value = self.portal.Language()
+        mock_content.absolute_url.return_value = expected_url
+
+        class MockNavRoot:
+            def __getattr__(self, name):
+                return mock_content
+
+        with patch(
+            f"{_GDPR_BASE_MODULE}.api.portal.get_navigation_root",
+            return_value=MockNavRoot(),
+        ):
+            with patch.object(self.request.response, "redirect") as mock_redirect:
+                view()
+
+        mock_redirect.assert_called_once_with(expected_url)

--- a/src/imio/smartweb/core/tests/test_ia.py
+++ b/src/imio/smartweb/core/tests/test_ia.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+
+from imio.smartweb.core.browser.ia.ia import ProcessCategorizeContentView
+from imio.smartweb.core.testing import IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+from imio.smartweb.core.testing import ImioSmartwebTestCase
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.textfield.value import RichTextValue
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import json
+
+
+_IA_MODULE = "imio.smartweb.core.browser.ia.ia"
+
+
+class TestProcessCategorizeContentView(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.page = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.Page",
+            title="A Page",
+        )
+
+    def _make_view(self, context=None):
+        if context is None:
+            context = self.page
+        return ProcessCategorizeContentView(context, self.request)
+
+    def _mock_taxonomy(self, inv_data=None):
+        """Return a mock ITaxonomy with given inv_data dict."""
+        if inv_data is None:
+            inv_data = {"publication": "Publication", "actualites": "Actualités"}
+        mock_taxo = MagicMock()
+        mock_taxo.makeVocabulary.return_value.inv_data = inv_data
+        return mock_taxo
+
+    # --- _get_all_text: IPages branch ---
+
+    def test_get_all_text_empty_for_page_with_no_sections(self):
+        view = self._make_view()
+        self.assertEqual(view._get_all_text(), "")
+
+    def test_get_all_text_collects_section_text_output(self):
+        section = api.content.create(
+            container=self.page,
+            type="imio.smartweb.SectionText",
+            title="Section",
+        )
+        section.text = RichTextValue("<p>Kamoulox</p>", "text/html", "text/html")
+        view = self._make_view()
+        result = view._get_all_text()
+        self.assertIn("Kamoulox", result)
+
+    def test_get_all_text_ignores_non_text_sections(self):
+        api.content.create(
+            container=self.page,
+            type="imio.smartweb.SectionFiles",
+            title="Files",
+        )
+        view = self._make_view()
+        self.assertEqual(view._get_all_text(), "")
+
+    def test_get_all_text_concatenates_multiple_text_sections(self):
+        for i in range(2):
+            section = api.content.create(
+                container=self.page,
+                type="imio.smartweb.SectionText",
+                title=f"Section {i}",
+            )
+            section.text = RichTextValue(f"<p>Part{i}</p>", "text/html", "text/html")
+        view = self._make_view()
+        result = view._get_all_text()
+        self.assertIn("Part0", result)
+        self.assertIn("Part1", result)
+
+    # --- _get_all_text: non-IPages (BODY) branch ---
+
+    def test_get_all_text_from_body_returns_form_title(self):
+        body = json.dumps({"formdata": {"form-widgets-IBasic-title": "Test Title"}})
+        view = self._make_view(context=self.portal)
+        with patch.object(self.request, "get", return_value=body):
+            result = view._get_all_text()
+        self.assertEqual(result, "Test Title")
+
+    def test_get_all_text_from_body_returns_empty_when_title_missing(self):
+        body = json.dumps({"formdata": {}})
+        view = self._make_view(context=self.portal)
+        with patch.object(self.request, "get", return_value=body):
+            result = view._get_all_text()
+        self.assertEqual(result, "")
+
+    # --- _process_category ---
+
+    def test_process_category_returns_empty_string_when_ia_returns_nothing(self):
+        view = self._make_view()
+        with patch(f"{_IA_MODULE}.get_categories", return_value=self._mock_taxonomy()):
+            with patch.object(view, "_ask_categorization_to_ia", return_value={}):
+                result = view._process_category("some text", {})
+        self.assertEqual(result, "")
+
+    def test_process_category_returns_categories_from_ia(self):
+        view = self._make_view()
+        ia_data = {"result": [{"title": "Publication", "token": "publication"}]}
+        with patch(f"{_IA_MODULE}.get_categories", return_value=self._mock_taxonomy()):
+            with patch.object(view, "_ask_categorization_to_ia", return_value=ia_data):
+                result = view._process_category("some text", {})
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["token"], "publication")
+        self.assertEqual(result[0]["title"], "Publication")
+
+    def test_process_category_returns_none_when_context_already_has_category(self):
+        self.page.taxonomy_page_category = "publication"
+        view = self._make_view()
+        result = view._process_category("some text", {})
+        self.assertIsNone(result)
+
+    def test_process_category_builds_vocab_from_taxonomy_inv_data(self):
+        """The vocabulary passed to the IA must reflect the taxonomy inv_data."""
+        view = self._make_view()
+        inv_data = {"token1": "Title1", "token2": "Title2"}
+        captured_voc = []
+
+        def capture_voc(text, voc):
+            captured_voc.extend(voc)
+            return {}
+
+        with patch(
+            f"{_IA_MODULE}.get_categories", return_value=self._mock_taxonomy(inv_data)
+        ):
+            with patch.object(
+                view, "_ask_categorization_to_ia", side_effect=capture_voc
+            ):
+                view._process_category("text", {})
+
+        tokens = {item["token"] for item in captured_voc}
+        self.assertIn("token1", tokens)
+        self.assertIn("token2", tokens)
+
+    # --- _process_specific ---
+
+    def test_process_specific_sets_taxonomy_page_category_key(self):
+        view = self._make_view()
+        with patch.object(view, "_process_category", return_value=[{"token": "x"}]):
+            results = {}
+            returned = view._process_specific("text", results)
+        self.assertIn("form-widgets-page_category-taxonomy_page_category", returned)
+        self.assertEqual(
+            returned["form-widgets-page_category-taxonomy_page_category"],
+            [{"token": "x"}],
+        )
+
+    def test_process_specific_returns_results(self):
+        view = self._make_view()
+        with patch.object(view, "_process_category", return_value=""):
+            results = {"existing": "value"}
+            returned = view._process_specific("text", results)
+        self.assertIsNotNone(returned)
+        self.assertIn("existing", returned)
+
+    # --- __call__ ---
+
+    def test_call_returns_valid_json(self):
+        view = self._make_view()
+        with patch(f"{_IA_MODULE}.get_categories", return_value=self._mock_taxonomy()):
+            with patch.object(view, "_ask_categorization_to_ia", return_value={}):
+                raw = view()
+        result = json.loads(raw)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["message"], "Catégorisation calculée")
+        self.assertIn("data", result)
+
+    def test_call_data_includes_taxonomy_page_category_key(self):
+        view = self._make_view()
+        ia_data = {"result": [{"title": "Publication", "token": "publication"}]}
+        with patch(f"{_IA_MODULE}.get_categories", return_value=self._mock_taxonomy()):
+            with patch.object(view, "_ask_categorization_to_ia", return_value=ia_data):
+                result = json.loads(view())
+        self.assertIn(
+            "form-widgets-page_category-taxonomy_page_category", result["data"]
+        )

--- a/src/imio/smartweb/core/tests/test_ideabox.py
+++ b/src/imio/smartweb/core/tests/test_ideabox.py
@@ -1,24 +1,41 @@
 # -*- coding: utf-8 -*-
+from imio.smartweb.core.contents import ICampaignView
+from imio.smartweb.core.contents.rest.campaign.endpoint import AllTopicsEndpoint
+from imio.smartweb.core.contents.rest.campaign.endpoint import AllTopicsEndpointGet
+from imio.smartweb.core.contents.rest.campaign.endpoint import AuthCampaignEndpointGet
 from imio.smartweb.core.contents.rest.campaign.endpoint import CampaignEndpoint
+from imio.smartweb.core.contents.rest.campaign.endpoint import CampaignEndpointGet
 from imio.smartweb.core.contents.rest.campaign.endpoint import (
     PROJECT_WORKFLOW_STATUS_TO_KEEP,
 )
-from imio.smartweb.core.contents import ICampaignView
+from imio.smartweb.core.contents.rest.campaign.endpoint import TopicsEndpoint
+from imio.smartweb.core.contents.rest.campaign.endpoint import TopicsEndpointGet
+from imio.smartweb.core.contents.rest.campaign.endpoint import TsTopicsEndpoint
+from imio.smartweb.core.contents.rest.campaign.endpoint import TsTopicsEndpointGet
+from imio.smartweb.core.contents.rest.campaign.endpoint import ZonesEndpoint
+from imio.smartweb.core.contents.rest.campaign.endpoint import ZonesEndpointGet
+from imio.smartweb.core.contents.rest.campaign.endpoint import (
+    get_ideabox_basic_auth_header,
+)
 from imio.smartweb.core.tests.utils import get_json
-
 from imio.smartweb.core.testing import IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
 from imio.smartweb.core.testing import ImioSmartwebTestCase
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.dexterity.interfaces import IDexterityFTI
+from unittest.mock import MagicMock
 from unittest.mock import patch
 from zope.component import createObject
 from zope.component import queryUtility
 from zope.publisher.browser import TestRequest
 
+import base64
 import json
 import requests_mock
+
+_ENDPOINT = "imio.smartweb.core.contents.rest.campaign.endpoint"
+_SUBSCRIBER = "imio.smartweb.core.subscribers"
 
 
 class TestIdeabox(ImioSmartwebTestCase):
@@ -152,3 +169,585 @@ class TestIdeabox(ImioSmartwebTestCase):
         self.assertEqual(call, {})
 
         # to be continued
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across new test classes
+# ---------------------------------------------------------------------------
+
+
+def _make_project(extra=None):
+    """Return a minimal project dict that satisfies CampaignEndpoint logic."""
+    project = {
+        "uuid": "test-uuid",
+        "id": "1",
+        "display_name": "Test Project",
+        "text": "Some text",
+        "url": "http://example.com/p/1",
+        "api_url": "http://example.com/api/p/1",
+        "fields": {"images_raw": [{"image": {"url": "http://example.com/img.png"}}]},
+        "workflow": {"status": "Publié"},
+        "user": {"name": "Alice"},
+        "roles": {"admin": []},
+        "submission": {"channel": "web"},
+        "evolution": [{"time": "2024-01-01", "status": "recorded"}],
+        "should_be_removed": "yes",
+    }
+    if extra:
+        project.update(extra)
+    return project
+
+
+class _CampaignViewMixin(ImioSmartwebTestCase):
+    """Mixin that creates a CampaignView while silencing subscriber API calls."""
+
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.folder = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.Folder",
+            title="Campaign Folder",
+        )
+        patcher_vfr = patch(
+            f"{_SUBSCRIBER}.get_value_from_registry",
+            return_value="https://staging.guichet-citoyen.be/api",
+        )
+        patcher_baj = patch(
+            f"{_SUBSCRIBER}.get_basic_auth_json",
+            return_value={"fields": {"titre": "Test Campaign", "description": "Desc"}},
+        )
+        patcher_vfr.start()
+        patcher_baj.start()
+        self.campaign_view = api.content.create(
+            id="test-campaign",
+            container=self.folder,
+            type="imio.smartweb.CampaignView",
+            linked_campaign="42",
+        )
+        patcher_vfr.stop()
+        patcher_baj.stop()
+
+    def _make_endpoint(self, form=None):
+        request = TestRequest(form=form or {})
+        return CampaignEndpoint(self.campaign_view, request)
+
+
+# ---------------------------------------------------------------------------
+# get_ideabox_basic_auth_header
+# ---------------------------------------------------------------------------
+
+
+class TestGetIdeaboxBasicAuthHeader(_CampaignViewMixin):
+
+    @patch(
+        "plone.api.portal.get_registry_record",
+        side_effect=lambda k: {
+            "smartweb.iaideabox_api_username": "user42",
+            "smartweb.iaideabox_api_password": "s3cr3t",
+        }[k],
+    )
+    def test_returns_basic_auth_header(self, _mock):
+        header = get_ideabox_basic_auth_header()
+        expected_b64 = base64.b64encode(b"user42:s3cr3t").decode("utf-8")
+        self.assertEqual(header, f"Basic {expected_b64}")
+
+    @patch(
+        "plone.api.portal.get_registry_record",
+        side_effect=lambda k: {
+            "smartweb.iaideabox_api_username": "a",
+            "smartweb.iaideabox_api_password": "b",
+        }[k],
+    )
+    def test_header_starts_with_basic(self, _mock):
+        header = get_ideabox_basic_auth_header()
+        self.assertTrue(header.startswith("Basic "))
+
+    @patch(
+        "plone.api.portal.get_registry_record",
+        side_effect=lambda k: {
+            "smartweb.iaideabox_api_username": "u",
+            "smartweb.iaideabox_api_password": "p",
+        }[k],
+    )
+    def test_header_b64_is_decodable(self, _mock):
+        header = get_ideabox_basic_auth_header()
+        b64_part = header[len("Basic ") :]
+        decoded = base64.b64decode(b64_part).decode("utf-8")
+        self.assertIn(":", decoded)
+
+
+# ---------------------------------------------------------------------------
+# CampaignEndpoint.__call__
+# ---------------------------------------------------------------------------
+
+
+class TestCampaignEndpointCall(_CampaignViewMixin):
+
+    def test_call_returns_empty_dict_when_no_json(self):
+        endpoint = self._make_endpoint()
+        with patch.object(endpoint, "_get_json", return_value=None):
+            result = endpoint()
+        self.assertEqual(result, {})
+
+    def test_call_returns_empty_dict_when_json_is_empty(self):
+        endpoint = self._make_endpoint()
+        with patch.object(endpoint, "_get_json", return_value={}):
+            result = endpoint()
+        self.assertEqual(result, {})
+
+    def test_call_returns_items_and_total_for_list(self):
+        endpoint = self._make_endpoint()
+        mock_resp = MagicMock()
+        mock_resp.content = b"img_bytes"
+        with patch.object(
+            endpoint, "_get_json", return_value={"data": [_make_project()], "count": 1}
+        ):
+            with patch.object(endpoint, "get_image", return_value=mock_resp):
+                result = endpoint()
+        self.assertIn("items", result)
+        self.assertIn("items_total", result)
+        self.assertEqual(result["items_total"], 1)
+        self.assertEqual(len(result["items"]), 1)
+
+    def test_call_filters_to_required_keys(self):
+        require_keys = {
+            "uuid",
+            "id",
+            "display_name",
+            "text",
+            "url",
+            "api_url",
+            "fields",
+            "workflow",
+        }
+        endpoint = self._make_endpoint()
+        mock_resp = MagicMock()
+        mock_resp.content = b"img"
+        with patch.object(
+            endpoint, "_get_json", return_value={"data": [_make_project()], "count": 1}
+        ):
+            with patch.object(endpoint, "get_image", return_value=mock_resp):
+                result = endpoint()
+        returned_keys = set(result["items"][0].keys())
+        self.assertTrue(returned_keys.issubset(require_keys))
+        self.assertNotIn("should_be_removed", returned_keys)
+        self.assertNotIn("user", returned_keys)
+
+    def test_call_items_total_comes_from_count(self):
+        endpoint = self._make_endpoint()
+        mock_resp = MagicMock()
+        mock_resp.content = b"img"
+        with patch.object(
+            endpoint,
+            "_get_json",
+            return_value={"data": [_make_project(), _make_project()], "count": 99},
+        ):
+            with patch.object(endpoint, "get_image", return_value=mock_resp):
+                result = endpoint()
+        self.assertEqual(result["items_total"], 99)
+
+    def test_call_returns_single_project_dict_when_no_data_key(self):
+        single = {
+            "uuid": "x",
+            "id": "3",
+            "title": "A project",
+            "evolution": ["something"],
+            "roles": {"r": []},
+            "submission": {"channel": "web"},
+            "user": {"name": "Bob"},
+        }
+        endpoint = self._make_endpoint()
+        with patch.object(endpoint, "_get_json", return_value=single):
+            result = endpoint()
+        self.assertEqual(result["uuid"], "x")
+        self.assertEqual(result["title"], "A project")
+
+    def test_call_removes_evolution_from_single_project(self):
+        single = {"uuid": "x", "evolution": ["e"], "id": "1"}
+        endpoint = self._make_endpoint()
+        with patch.object(endpoint, "_get_json", return_value=single):
+            result = endpoint()
+        self.assertNotIn("evolution", result)
+
+    def test_call_removes_roles_from_single_project(self):
+        single = {"uuid": "x", "roles": {"admin": []}, "id": "1"}
+        endpoint = self._make_endpoint()
+        with patch.object(endpoint, "_get_json", return_value=single):
+            result = endpoint()
+        self.assertNotIn("roles", result)
+
+    def test_call_removes_submission_from_single_project(self):
+        single = {"uuid": "x", "submission": {"channel": "web"}, "id": "1"}
+        endpoint = self._make_endpoint()
+        with patch.object(endpoint, "_get_json", return_value=single):
+            result = endpoint()
+        self.assertNotIn("submission", result)
+
+    def test_call_removes_user_from_single_project(self):
+        single = {"uuid": "x", "user": {"name": "Bob"}, "id": "1"}
+        endpoint = self._make_endpoint()
+        with patch.object(endpoint, "_get_json", return_value=single):
+            result = endpoint()
+        self.assertNotIn("user", result)
+
+
+# ---------------------------------------------------------------------------
+# CampaignEndpoint.query_url
+# ---------------------------------------------------------------------------
+
+
+class TestCampaignEndpointQueryUrl(_CampaignViewMixin):
+
+    @patch(f"{_ENDPOINT}.get_ts_api_url", return_value="https://wcs.example.be/api")
+    def test_query_url_with_specific_id_returns_single_project_url(self, _mock):
+        endpoint = self._make_endpoint(form={"id": "7"})
+        url = endpoint.query_url
+        self.assertIn("/cards/imio-ideabox-projet/7", url)
+        self.assertIn("full=on", url)
+        self.assertNotIn("filter-campagne", url)
+
+    @patch(f"{_ENDPOINT}.get_ts_api_url", return_value="https://wcs.example.be/api")
+    def test_query_url_list_contains_campaign_id(self, _mock):
+        endpoint = self._make_endpoint()
+        url = endpoint.query_url
+        self.assertIn("filter-campagne=42", url)
+        self.assertIn("filter-statut", url)
+        self.assertIn("filter-statut-operator=in", url)
+
+    @patch(f"{_ENDPOINT}.get_ts_api_url", return_value="https://wcs.example.be/api")
+    def test_query_url_list_contains_all_workflow_statuses(self, _mock):
+        endpoint = self._make_endpoint()
+        url = endpoint.query_url
+        for status in PROJECT_WORKFLOW_STATUS_TO_KEEP:
+            self.assertIn(status, url)
+
+    @patch(f"{_ENDPOINT}.get_ts_api_url", return_value="https://wcs.example.be/api")
+    def test_query_url_list_appends_extra_form_params(self, _mock):
+        endpoint = self._make_endpoint(form={"zone": "nord", "topic": "education"})
+        url = endpoint.query_url
+        self.assertIn("zone=nord", url)
+        self.assertIn("topic=education", url)
+
+
+# ---------------------------------------------------------------------------
+# CampaignEndpoint.get_image
+# ---------------------------------------------------------------------------
+
+
+class TestGetImage(_CampaignViewMixin):
+
+    def test_get_image_returns_none_for_empty_url(self):
+        endpoint = self._make_endpoint()
+        result = endpoint.get_image("")
+        self.assertIsNone(result)
+
+    def test_get_image_returns_none_for_none_url(self):
+        endpoint = self._make_endpoint()
+        result = endpoint.get_image(None)
+        self.assertIsNone(result)
+
+    @patch(f"{_ENDPOINT}.requests.get")
+    @patch(
+        "plone.api.portal.get_registry_record",
+        side_effect=lambda k: {
+            "smartweb.iaideabox_api_username": "u",
+            "smartweb.iaideabox_api_password": "p",
+        }[k],
+    )
+    def test_get_image_calls_requests_get(self, _mock_reg, mock_get):
+        mock_get.return_value = MagicMock(content=b"imgdata")
+        endpoint = self._make_endpoint()
+        result = endpoint.get_image("http://example.com/img.png")
+        mock_get.assert_called_once()
+        self.assertEqual(result.content, b"imgdata")
+
+    @patch(f"{_ENDPOINT}.requests.get")
+    @patch(
+        "plone.api.portal.get_registry_record",
+        side_effect=lambda k: {
+            "smartweb.iaideabox_api_username": "u",
+            "smartweb.iaideabox_api_password": "p",
+        }[k],
+    )
+    def test_get_image_sends_authorization_header(self, _mock_reg, mock_get):
+        mock_get.return_value = MagicMock(content=b"img")
+        endpoint = self._make_endpoint()
+        endpoint.get_image("http://example.com/img.png")
+        call_kwargs = mock_get.call_args[1]
+        self.assertIn("Authorization", call_kwargs.get("headers", {}))
+        self.assertTrue(call_kwargs["headers"]["Authorization"].startswith("Basic "))
+
+    @patch(f"{_ENDPOINT}.requests.get")
+    @patch(
+        "plone.api.portal.get_registry_record",
+        side_effect=lambda k: {
+            "smartweb.iaideabox_api_username": "u",
+            "smartweb.iaideabox_api_password": "p",
+        }[k],
+    )
+    def test_get_image_sends_accept_header(self, _mock_reg, mock_get):
+        mock_get.return_value = MagicMock(content=b"img")
+        endpoint = self._make_endpoint()
+        endpoint.get_image("http://example.com/img.png")
+        call_kwargs = mock_get.call_args[1]
+        self.assertEqual(call_kwargs.get("headers", {}).get("Accept"), "image/*")
+
+
+# ---------------------------------------------------------------------------
+# CampaignEndpoint.add_b64_image_to_data
+# ---------------------------------------------------------------------------
+
+
+class TestAddB64Image(_CampaignViewMixin):
+
+    def test_add_b64_image_encodes_content(self):
+        endpoint = self._make_endpoint()
+        mock_resp = MagicMock()
+        mock_resp.content = b"raw_image_bytes"
+        expected_b64 = base64.b64encode(b"raw_image_bytes").decode("utf-8")
+        data = [
+            {
+                "fields": {
+                    "images_raw": [{"image": {"url": "http://example.com/img.png"}}]
+                }
+            }
+        ]
+        with patch.object(endpoint, "get_image", return_value=mock_resp):
+            result = endpoint.add_b64_image_to_data(data)
+        self.assertEqual(
+            result[0]["fields"]["images_raw"][0]["image"]["content"], expected_b64
+        )
+
+    def test_add_b64_image_fetches_url_from_fields(self):
+        endpoint = self._make_endpoint()
+        mock_resp = MagicMock()
+        mock_resp.content = b"bytes"
+        image_url = "http://example.com/specific-image.png"
+        data = [{"fields": {"images_raw": [{"image": {"url": image_url}}]}}]
+        with patch.object(
+            endpoint, "get_image", return_value=mock_resp
+        ) as mock_get_image:
+            endpoint.add_b64_image_to_data(data)
+        mock_get_image.assert_called_once_with(image_url)
+
+    def test_add_b64_image_processes_all_items(self):
+        endpoint = self._make_endpoint()
+        mock_resp = MagicMock()
+        mock_resp.content = b"img"
+
+        def make_item(url):
+            return {"fields": {"images_raw": [{"image": {"url": url}}]}}
+
+        data = [make_item("http://a.com/1.png"), make_item("http://b.com/2.png")]
+        with patch.object(endpoint, "get_image", return_value=mock_resp):
+            result = endpoint.add_b64_image_to_data(data)
+        self.assertEqual(len(result), 2)
+        for item in result:
+            self.assertIn("content", item["fields"]["images_raw"][0]["image"])
+
+
+# ---------------------------------------------------------------------------
+# ZonesEndpoint
+# ---------------------------------------------------------------------------
+
+
+class TestZonesEndpoint(_CampaignViewMixin):
+
+    def _make_zones_endpoint(self):
+        return ZonesEndpoint(self.campaign_view, TestRequest())
+
+    @patch(f"{_ENDPOINT}.get_ts_api_url", return_value="https://wcs.example.be/api")
+    def test_query_url_contains_campaign_id(self, _mock):
+        endpoint = self._make_zones_endpoint()
+        url = endpoint.query_url
+        self.assertIn("42", url)
+        self.assertIn("imio-ideabox-zone", url)
+
+    def test_call_returns_empty_on_no_json(self):
+        endpoint = self._make_zones_endpoint()
+        with patch.object(endpoint, "_get_json", return_value=None):
+            result = endpoint()
+        self.assertEqual(result, {"items": [], "items_total": 0})
+
+    def test_call_returns_items_and_total(self):
+        zones = [{"id": "1", "text": "Zone A"}, {"id": "2", "text": "Zone B"}]
+        endpoint = self._make_zones_endpoint()
+        with patch.object(
+            endpoint, "_get_json", return_value={"data": zones, "count": 2}
+        ):
+            result = endpoint()
+        self.assertEqual(result["items"], zones)
+        self.assertEqual(result["items_total"], 2)
+
+
+# ---------------------------------------------------------------------------
+# TsTopicsEndpoint
+# ---------------------------------------------------------------------------
+
+
+class TestTsTopicsEndpoint(_CampaignViewMixin):
+
+    def _make_ts_topics_endpoint(self):
+        return TsTopicsEndpoint(self.campaign_view, TestRequest())
+
+    @patch(f"{_ENDPOINT}.get_ts_api_url", return_value="https://wcs.example.be/api")
+    def test_query_url_contains_campaign_id(self, _mock):
+        endpoint = self._make_ts_topics_endpoint()
+        url = endpoint.query_url
+        self.assertIn("42", url)
+        self.assertIn("imio-ideabox-theme", url)
+
+    def test_call_returns_empty_on_no_json(self):
+        endpoint = self._make_ts_topics_endpoint()
+        with patch.object(endpoint, "_get_json", return_value=None):
+            result = endpoint()
+        self.assertEqual(result, {"items": [], "items_total": 0})
+
+    def test_call_returns_items_and_total(self):
+        topics = [{"id": "1", "text": "Topic 1"}]
+        endpoint = self._make_ts_topics_endpoint()
+        with patch.object(
+            endpoint, "_get_json", return_value={"data": topics, "count": 1}
+        ):
+            result = endpoint()
+        self.assertEqual(result["items"], topics)
+        self.assertEqual(result["items_total"], 1)
+
+
+# ---------------------------------------------------------------------------
+# TopicsEndpoint
+# ---------------------------------------------------------------------------
+
+
+class TestTopicsEndpoint(_CampaignViewMixin):
+
+    def _make_topics_endpoint(self):
+        return TopicsEndpoint(self.campaign_view, TestRequest())
+
+    def test_call_returns_items_and_items_total(self):
+        endpoint = self._make_topics_endpoint()
+        result = endpoint()
+        self.assertIn("items", result)
+        self.assertIn("items_total", result)
+        self.assertEqual(result["items_total"], len(result["items"]))
+
+    def test_call_items_have_value_and_title(self):
+        endpoint = self._make_topics_endpoint()
+        result = endpoint()
+        for item in result["items"]:
+            self.assertIn("value", item)
+            self.assertIn("title", item)
+
+
+# ---------------------------------------------------------------------------
+# AllTopicsEndpoint
+# ---------------------------------------------------------------------------
+
+
+class TestAllTopicsEndpoint(_CampaignViewMixin):
+
+    def _make_all_topics_endpoint(self):
+        return AllTopicsEndpoint(self.campaign_view, TestRequest())
+
+    def test_call_combines_vocabulary_and_ts_topics(self):
+        endpoint = self._make_all_topics_endpoint()
+        ts_mock = {"items": [{"id": "ts1", "text": "TS Topic"}], "items_total": 1}
+        with patch.object(TsTopicsEndpoint, "__call__", return_value=ts_mock):
+            result = endpoint()
+        titles = [item["title"] for item in result["items"]]
+        self.assertIn("TS Topic", titles)
+
+    def test_call_items_total_reflects_combined_count(self):
+        endpoint = self._make_all_topics_endpoint()
+        ts_mock = {
+            "items": [{"id": "ts1", "text": "A"}, {"id": "ts2", "text": "B"}],
+            "items_total": 2,
+        }
+        with patch.object(TsTopicsEndpoint, "__call__", return_value=ts_mock):
+            result = endpoint()
+        self.assertEqual(result["items_total"], len(result["items"]))
+
+    def test_call_result_is_sorted_by_title(self):
+        endpoint = self._make_all_topics_endpoint()
+        ts_mock = {
+            "items": [{"id": "z", "text": "Zzz"}, {"id": "a", "text": "Aaa"}],
+            "items_total": 2,
+        }
+        with patch.object(TsTopicsEndpoint, "__call__", return_value=ts_mock):
+            result = endpoint()
+        titles = [item["title"] for item in result["items"]]
+        self.assertEqual(titles, sorted(titles, key=lambda t: t.lower()))
+
+
+# ---------------------------------------------------------------------------
+# Service classes (reply())
+# ---------------------------------------------------------------------------
+
+
+class TestServiceClasses(_CampaignViewMixin):
+    """Service classes are thin wrappers around endpoint __call__.
+
+    <plone:service> creates a BrowserView subclass in ZCA, but the imported
+    class has no __init__.  We bypass this by using __new__ + manual attribute
+    assignment so we can test reply() in isolation.
+    """
+
+    def _make_service(self, cls):
+        svc = object.__new__(cls)
+        svc.context = self.campaign_view
+        svc.request = TestRequest()
+        return svc
+
+    def test_campaign_endpoint_get_reply(self):
+        service = self._make_service(CampaignEndpointGet)
+        with patch.object(
+            CampaignEndpoint, "__call__", return_value={"items": [], "items_total": 0}
+        ):
+            result = service.reply()
+        self.assertEqual(result, {"items": [], "items_total": 0})
+
+    @patch(
+        "plone.api.portal.get_registry_record",
+        side_effect=lambda k: {
+            "smartweb.iaideabox_api_username": "u",
+            "smartweb.iaideabox_api_password": "p",
+        }[k],
+    )
+    def test_auth_campaign_endpoint_get_reply(self, _mock):
+        service = self._make_service(AuthCampaignEndpointGet)
+        result = service.reply()
+        self.assertTrue(result.startswith("Basic "))
+
+    def test_zones_endpoint_get_reply(self):
+        service = self._make_service(ZonesEndpointGet)
+        with patch.object(
+            ZonesEndpoint, "__call__", return_value={"items": [], "items_total": 0}
+        ):
+            result = service.reply()
+        self.assertEqual(result["items_total"], 0)
+
+    def test_ts_topics_endpoint_get_reply(self):
+        # TsTopicsEndpointGet.reply() delegates to ZonesEndpoint (see source)
+        service = self._make_service(TsTopicsEndpointGet)
+        with patch.object(
+            ZonesEndpoint, "__call__", return_value={"items": [], "items_total": 0}
+        ):
+            result = service.reply()
+        self.assertIn("items", result)
+
+    def test_topics_endpoint_get_reply(self):
+        service = self._make_service(TopicsEndpointGet)
+        result = service.reply()
+        self.assertIn("items", result)
+        self.assertIn("items_total", result)
+
+    def test_all_topics_endpoint_get_reply(self):
+        service = self._make_service(AllTopicsEndpointGet)
+        ts_mock = {"items": [], "items_total": 0}
+        with patch.object(TsTopicsEndpoint, "__call__", return_value=ts_mock):
+            result = service.reply()
+        self.assertIn("items", result)

--- a/src/imio/smartweb/core/tests/test_init.py
+++ b/src/imio/smartweb/core/tests/test_init.py
@@ -1,0 +1,277 @@
+# -*- coding: utf-8 -*-
+
+import importlib
+import os
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import imio.smartweb.core as init_module
+
+
+class TestInitMonkeyPatch(unittest.TestCase):
+    """Tests for the NamedBlobImage monkeypatch conditional logic in __init__.py"""
+
+    def setUp(self):
+        from plone.namedfile.file import NamedBlobImage
+
+        self._NamedBlobImage = NamedBlobImage
+        self._original_setdata = NamedBlobImage._setData
+
+    def tearDown(self):
+        # Restore original _setData on NamedBlobImage
+        self._NamedBlobImage._setData = self._original_setdata
+        # Reload module back to non-liege state so we don't pollute other tests
+        with patch.dict(os.environ, {"PROJECT_ID": ""}):
+            importlib.reload(init_module)
+
+    def _reload_with_project_id(self, project_id):
+        with patch.dict(os.environ, {"PROJECT_ID": project_id}):
+            importlib.reload(init_module)
+
+    # --- Activation / deactivation ---
+
+    def test_patch_not_applied_with_empty_project_id(self):
+        """Patch should NOT be applied when PROJECT_ID is absent/empty"""
+        self._reload_with_project_id("")
+        self.assertIs(self._NamedBlobImage._setData, self._original_setdata)
+
+    def test_patch_not_applied_with_other_project_id(self):
+        """Patch should NOT be applied when PROJECT_ID is a different value"""
+        self._reload_with_project_id("other_project")
+        self.assertIs(self._NamedBlobImage._setData, self._original_setdata)
+
+    def test_patch_applied_with_liege_smartweb(self):
+        """Patch SHOULD be applied when PROJECT_ID == 'liege_smartweb'"""
+        self._reload_with_project_id("liege_smartweb")
+        self.assertIsNot(self._NamedBlobImage._setData, self._original_setdata)
+
+    # --- Log messages ---
+
+    def test_log_message_not_activated(self):
+        """Should log info message containing 'NOT activated' when patch is skipped"""
+        with patch.dict(os.environ, {"PROJECT_ID": ""}):
+            with self.assertLogs("imio.smartweb.core", level="INFO") as cm:
+                importlib.reload(init_module)
+        self.assertTrue(any("NOT activated" in msg for msg in cm.output))
+
+    def test_log_message_activated_on_call(self):
+        """patched_setData should log an info message when called"""
+        self._reload_with_project_id("liege_smartweb")
+
+        mock_self = MagicMock()
+        mock_self.filename = "test.jpg"
+        mock_self.getFirstBytes.return_value = b"x" * 100
+
+        with patch.object(init_module, "NamedBlobFile"):
+            with patch.object(
+                init_module, "getImageInfo", return_value=("image/jpeg", 100, 200)
+            ):
+                with self.assertLogs("imio.smartweb.core", level="INFO") as cm:
+                    self._NamedBlobImage._setData(mock_self, b"data")
+
+        self.assertTrue(any("test.jpg" in msg for msg in cm.output))
+
+    # --- patched_setData behaviour ---
+
+    def test_patched_setdata_calls_parent(self):
+        """patched_setData should call NamedBlobFile._setData with (self, data)"""
+        self._reload_with_project_id("liege_smartweb")
+
+        mock_self = MagicMock()
+        mock_self.filename = "test.png"
+        mock_self.getFirstBytes.return_value = b"x" * 100
+        fake_data = b"fake_image_data"
+
+        with patch.object(init_module, "NamedBlobFile") as mock_blobfile_class:
+            with patch.object(
+                init_module, "getImageInfo", return_value=("image/png", 100, 200)
+            ):
+                self._NamedBlobImage._setData(mock_self, fake_data)
+
+        mock_blobfile_class._setData.assert_called_once_with(mock_self, fake_data)
+
+    def test_patched_setdata_sets_width_and_height(self):
+        """patched_setData should set _width and _height from getImageInfo"""
+        self._reload_with_project_id("liege_smartweb")
+
+        mock_self = MagicMock()
+        mock_self.filename = "test.png"
+        mock_self.getFirstBytes.return_value = b"x" * 100
+
+        with patch.object(init_module, "NamedBlobFile"):
+            with patch.object(
+                init_module, "getImageInfo", return_value=("image/png", 800, 600)
+            ):
+                self._NamedBlobImage._setData(mock_self, b"data")
+
+        self.assertEqual(mock_self._width, 800)
+        self.assertEqual(mock_self._height, 600)
+
+    def test_patched_setdata_sets_content_type(self):
+        """patched_setData should set contentType when getImageInfo returns a non-empty type"""
+        self._reload_with_project_id("liege_smartweb")
+
+        mock_self = MagicMock()
+        mock_self.filename = "test.png"
+        mock_self.getFirstBytes.return_value = b"x" * 100
+
+        with patch.object(init_module, "NamedBlobFile"):
+            with patch.object(
+                init_module, "getImageInfo", return_value=("image/png", 800, 600)
+            ):
+                self._NamedBlobImage._setData(mock_self, b"data")
+
+        self.assertEqual(mock_self.contentType, "image/png")
+
+    def test_patched_setdata_skips_content_type_when_empty(self):
+        """patched_setData should NOT set contentType when getImageInfo returns an empty type"""
+        self._reload_with_project_id("liege_smartweb")
+
+        # Track whether contentType was assigned via a property
+        class TrackedImage:
+            def __init__(self):
+                self.filename = "test.bin"
+                self._width = None
+                self._height = None
+                self._content_type_set = False
+                self._content_type = "original"
+
+            def getFirstBytes(self, *args, **kwargs):
+                return b"data"
+
+            @property
+            def contentType(self):
+                return self._content_type
+
+            @contentType.setter
+            def contentType(self, value):
+                self._content_type = value
+                self._content_type_set = True
+
+        tracked = TrackedImage()
+
+        with patch.object(init_module, "NamedBlobFile"):
+            with patch.object(init_module, "getImageInfo", return_value=("", -1, -1)):
+                self._NamedBlobImage._setData(tracked, b"data")
+
+        self.assertFalse(tracked._content_type_set)
+        self.assertEqual(tracked._content_type, "original")
+
+    # --- Re-fetch logic for images with -1 dimensions ---
+
+    def _assert_refetch_behaviour(self, initial_mimetype, resolved_mimetype):
+        """Helper: verify that -1 dimensions trigger a second getFirstBytes call."""
+        self._reload_with_project_id("liege_smartweb")
+
+        first_bytes = b"x" * 10
+        extra_bytes = b"extra"
+
+        mock_self = MagicMock()
+        mock_self.filename = f"test.{initial_mimetype.split('/')[-1]}"
+        mock_self.getFirstBytes.side_effect = [first_bytes, extra_bytes]
+
+        with patch.object(init_module, "NamedBlobFile"):
+            with patch.object(init_module, "getImageInfo") as mock_getimageinfo:
+                mock_getimageinfo.side_effect = [
+                    (initial_mimetype, -1, -1),
+                    (resolved_mimetype, 800, 600),
+                ]
+                self._NamedBlobImage._setData(mock_self, b"data")
+
+        self.assertEqual(mock_self.getFirstBytes.call_count, 2)
+        self.assertEqual(mock_self._width, 800)
+        self.assertEqual(mock_self._height, 600)
+        self.assertEqual(mock_self.contentType, resolved_mimetype)
+
+    def test_jpeg_negative_dimensions_triggers_refetch(self):
+        """JPEG with -1 dimensions should trigger a second byte fetch"""
+        self._assert_refetch_behaviour("image/jpeg", "image/jpeg")
+
+    def test_tiff_negative_dimensions_triggers_refetch(self):
+        """TIFF with -1 dimensions should trigger a second byte fetch"""
+        self._assert_refetch_behaviour("image/tiff", "image/tiff")
+
+    def test_svg_negative_dimensions_triggers_refetch(self):
+        """SVG with -1 dimensions should trigger a second byte fetch"""
+        self._assert_refetch_behaviour("image/svg+xml", "image/svg+xml")
+
+    def test_jpeg_valid_dimensions_no_refetch(self):
+        """JPEG with valid dimensions should NOT trigger a second byte fetch"""
+        self._reload_with_project_id("liege_smartweb")
+
+        mock_self = MagicMock()
+        mock_self.filename = "test.jpg"
+        mock_self.getFirstBytes.return_value = b"x" * 100
+
+        with patch.object(init_module, "NamedBlobFile"):
+            with patch.object(
+                init_module, "getImageInfo", return_value=("image/jpeg", 640, 480)
+            ):
+                self._NamedBlobImage._setData(mock_self, b"data")
+
+        self.assertEqual(mock_self.getFirstBytes.call_count, 1)
+        self.assertEqual(mock_self._width, 640)
+        self.assertEqual(mock_self._height, 480)
+
+    def test_png_negative_dimensions_no_refetch(self):
+        """PNG with -1 dimensions should NOT trigger a refetch (only JPEG/TIFF/SVG do)"""
+        self._reload_with_project_id("liege_smartweb")
+
+        mock_self = MagicMock()
+        mock_self.filename = "test.png"
+        mock_self.getFirstBytes.return_value = b"x" * 100
+
+        with patch.object(init_module, "NamedBlobFile"):
+            with patch.object(
+                init_module, "getImageInfo", return_value=("image/png", -1, -1)
+            ):
+                self._NamedBlobImage._setData(mock_self, b"data")
+
+        self.assertEqual(mock_self.getFirstBytes.call_count, 1)
+
+    def test_refetch_uses_correct_getfirstbytes_args(self):
+        """Second getFirstBytes call should pass (start, length) derived from MAX_INFO_BYTES"""
+        self._reload_with_project_id("liege_smartweb")
+
+        MAX_INFO_BYTES = init_module.MAX_INFO_BYTES
+        first_bytes = b"x" * 10
+        expected_start = len(first_bytes)
+        expected_length = max(0, MAX_INFO_BYTES - expected_start)
+
+        mock_self = MagicMock()
+        mock_self.filename = "test.jpg"
+        mock_self.getFirstBytes.side_effect = [first_bytes, b"more"]
+
+        with patch.object(init_module, "NamedBlobFile"):
+            with patch.object(init_module, "getImageInfo") as mock_getimageinfo:
+                mock_getimageinfo.side_effect = [
+                    ("image/jpeg", -1, -1),
+                    ("image/jpeg", 100, 200),
+                ]
+                self._NamedBlobImage._setData(mock_self, b"data")
+
+        second_call = mock_self.getFirstBytes.call_args_list[1]
+        self.assertEqual(second_call, call(expected_start, expected_length))
+
+    def test_refetch_passes_combined_bytes_to_getimageinfo(self):
+        """Second getImageInfo call should receive concatenated firstbytes"""
+        self._reload_with_project_id("liege_smartweb")
+
+        first_bytes = b"FIRST"
+        extra_bytes = b"EXTRA"
+
+        mock_self = MagicMock()
+        mock_self.filename = "test.jpg"
+        mock_self.getFirstBytes.side_effect = [first_bytes, extra_bytes]
+
+        with patch.object(init_module, "NamedBlobFile"):
+            with patch.object(init_module, "getImageInfo") as mock_getimageinfo:
+                mock_getimageinfo.side_effect = [
+                    ("image/jpeg", -1, -1),
+                    ("image/jpeg", 100, 200),
+                ]
+                self._NamedBlobImage._setData(mock_self, b"data")
+
+        # First call: original data; second call: combined firstbytes
+        second_call_arg = mock_getimageinfo.call_args_list[1][0][0]
+        self.assertEqual(second_call_arg, first_bytes + extra_bytes)

--- a/src/imio/smartweb/core/tests/test_rest.py
+++ b/src/imio/smartweb/core/tests/test_rest.py
@@ -494,7 +494,7 @@ class SectionsFunctionalTest(ImioSmartwebTestCase):
             # "entity_uid=7c69f9a738ec497c819725c55888ee32&"
             self.assertEqual(
                 url,
-                "http://localhost:8080/Plone/@search?"
+                "http://localhost:8080/Plone/@search_newsitems?"
                 "selected_news_folders={}&"
                 "portal_type=imio.news.NewsItem&"
                 "metadata_fields=category&"
@@ -505,6 +505,7 @@ class SectionsFunctionalTest(ImioSmartwebTestCase):
                 "metadata_fields=UID&"
                 "sort_on=effective&"
                 "sort_order=descending&"
+                "entity_uid=7c69f9a738ec497c819725c55888ee32&"
                 "fullobjects=1&"
                 "b_size=20&"
                 "translated_in_en=1".format(self.rest_news.selected_news_folder),

--- a/src/imio/smartweb/core/tests/test_rest_views.py
+++ b/src/imio/smartweb/core/tests/test_rest_views.py
@@ -1,0 +1,1032 @@
+# -*- coding: utf-8 -*-
+
+from imio.smartweb.core.contents.rest.base import BaseEndpoint
+from imio.smartweb.core.contents.rest.directory.view import (
+    DirectoryViewView,
+)  # noqa: F401
+from imio.smartweb.core.contents.rest.events.view import EventsViewView  # noqa: F401
+from imio.smartweb.core.contents.rest.news.endpoint import NewsEndpoint
+from imio.smartweb.core.contents.rest.news.endpoint import NewsEndpointGet
+from imio.smartweb.core.contents.rest.news.endpoint import NewsFiltersEndpoint
+from imio.smartweb.core.contents.rest.news.endpoint import NewsFiltersEndpointGet
+from imio.smartweb.core.contents.rest.news.view import NewsViewView  # noqa: F401
+from imio.smartweb.core.testing import IMIO_SMARTWEB_CORE_FUNCTIONAL_TESTING
+from imio.smartweb.core.testing import IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+from imio.smartweb.core.testing import ImioSmartwebTestCase
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest.mock import patch
+from zope.component import queryMultiAdapter
+
+import requests_mock
+
+
+_NEWS_ENDPOINT_MODULE = "imio.smartweb.core.contents.rest.news.endpoint"
+_BASE_MODULE = "imio.smartweb.core.contents.rest.base"
+_DIR_VIEW_MODULE = "imio.smartweb.core.contents.rest.directory.view"
+
+
+class TestBaseRestView(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.request = self.layer["request"]
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.events_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.EventsView",
+            title="Events view",
+            id="events-view",
+        )
+
+    def _get_view(self):
+        return queryMultiAdapter((self.events_view, self.request), name="view")
+
+    def test_batch_size(self):
+        self.events_view.nb_results = 12
+        view = self._get_view()
+        self.assertEqual(view.batch_size, 12)
+
+    def test_local_query_url(self):
+        view = self._get_view()
+        self.assertIn("@results", view.local_query_url)
+        self.assertIn(self.events_view.absolute_url(), view.local_query_url)
+
+    def test_local_filters_query_url(self):
+        view = self._get_view()
+        self.assertIn("@results-filters", view.local_filters_query_url)
+
+    def test_orientation(self):
+        self.events_view.orientation = "portrait"
+        view = self._get_view()
+        self.assertEqual(view.orientation, "portrait")
+
+    def test_current_language(self):
+        view = self._get_view()
+        self.assertIn(view.current_language, ["en", "fr", "nl", "de"])
+
+    def test_context_authenticated_user(self):
+        view = self._get_view()
+        # In tests we have a logged-in user
+        self.assertFalse(view.context_authenticated_user)
+
+    def test_view_path(self):
+        view = self._get_view()
+        path = view.view_path
+        self.assertIn("/plone/", path)
+        self.assertNotIn("http://", path)
+        self.assertNotIn("https://", path)
+
+    def test_format_address_full(self):
+        view = self._get_view()
+        result = view._format_address(
+            street="Rue de la Loi",
+            number="16",
+            zipcode=1000,
+            city="Bruxelles",
+            country="Belgique",
+        )
+        self.assertIn("Rue de la Loi", result)
+        self.assertIn("16", result)
+        self.assertIn("1000", result)
+        self.assertIn("Bruxelles", result)
+        self.assertIn("Belgique", result)
+
+    def test_format_address_partial(self):
+        view = self._get_view()
+        # Only city and zipcode
+        result = view._format_address(zipcode=4000, city="Liège")
+        self.assertIn("4000", result)
+        self.assertIn("Liège", result)
+        self.assertNotIn("/", result)
+
+    def test_format_address_empty(self):
+        view = self._get_view()
+        result = view._format_address()
+        self.assertEqual(result, "")
+
+    def test_direct_access_without_uuid(self):
+        self.request.environ["QUERY_STRING"] = ""
+        view = self._get_view()
+        self.assertFalse(view.direct_access)
+
+    @requests_mock.Mocker()
+    def test_direct_access_with_uuid_no_referer(self, m):
+        uuid = "abc123def456"
+        self.request.environ["QUERY_STRING"] = f"u={uuid}"
+        self.request.environ["HTTP_REFERER"] = ""
+        mock_data = {"items": [{"UID": uuid, "title": "Test Event"}], "items_total": 1}
+        m.get(requests_mock.ANY, json=mock_data)
+        view = self._get_view()
+        self.assertTrue(view.direct_access)
+        self.assertIsNotNone(view.item)
+        self.assertEqual(view.item.get("title"), "Test Event")
+
+    def test_direct_access_with_referer(self):
+        uuid = "abc123def456"
+        self.request.environ["QUERY_STRING"] = f"u={uuid}"
+        self.request.environ["HTTP_REFERER"] = "http://some-referer.be"
+        view = self._get_view()
+        self.assertFalse(view.direct_access)
+
+
+class TestSeoHiddenReactLinks(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.request = self.layer["request"]
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.events_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.EventsView",
+            title="Events view",
+            id="events-view",
+        )
+        self.news_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.NewsView",
+            title="News view",
+            id="news-view",
+        )
+        self.directory_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.DirectoryView",
+            title="Directory view",
+            id="directory-view",
+        )
+
+    def _mock_endpoint_data(self, items=None):
+        return {"items": items or [], "items_total": len(items or [])}
+
+    @patch("imio.smartweb.core.contents.rest.view.get_endpoint_data")
+    @patch("imio.smartweb.core.contents.rest.view.format_sitemap_items")
+    def test_seo_hidden_react_links_events(self, mock_format, mock_endpoint):
+        mock_endpoint.return_value = {"items": [], "items_total": 0}
+        mock_format.return_value = []
+        view = queryMultiAdapter((self.events_view, self.request), name="seo_html")
+        view()
+        self.assertEqual(view.total, 0)
+        self.assertEqual(view.get_data, [])
+        self.assertEqual(view.default_view, self.events_view.absolute_url())
+
+    @patch("imio.smartweb.core.contents.rest.view.get_endpoint_data")
+    @patch("imio.smartweb.core.contents.rest.view.format_sitemap_items")
+    def test_seo_hidden_react_links_label_events(self, mock_format, mock_endpoint):
+        mock_endpoint.return_value = {"items": [], "items_total": 0}
+        mock_format.return_value = []
+        view = queryMultiAdapter((self.events_view, self.request), name="seo_html")
+        view()
+        label = view.label
+        self.assertIsNotNone(label)
+
+    @patch("imio.smartweb.core.contents.rest.view.get_endpoint_data")
+    @patch("imio.smartweb.core.contents.rest.view.format_sitemap_items")
+    def test_seo_hidden_react_links_label_news(self, mock_format, mock_endpoint):
+        mock_endpoint.return_value = {"items": [], "items_total": 0}
+        mock_format.return_value = []
+        view = queryMultiAdapter((self.news_view, self.request), name="seo_html")
+        view()
+        label = view.label
+        self.assertIsNotNone(label)
+
+    @patch("imio.smartweb.core.contents.rest.view.get_endpoint_data")
+    @patch("imio.smartweb.core.contents.rest.view.format_sitemap_items")
+    def test_seo_hidden_react_links_label_directory(self, mock_format, mock_endpoint):
+        mock_endpoint.return_value = {"items": [], "items_total": 0}
+        mock_format.return_value = []
+        view = queryMultiAdapter((self.directory_view, self.request), name="seo_html")
+        view()
+        label = view.label
+        self.assertIsNotNone(label)
+
+    @patch("imio.smartweb.core.contents.rest.view.get_endpoint_data")
+    @patch("imio.smartweb.core.contents.rest.view.format_sitemap_items")
+    def test_seo_hidden_react_links_items_total(self, mock_format, mock_endpoint):
+        # items_total from endpoint data is used as total (items list stays empty for template compat)
+        mock_endpoint.return_value = {"items": [], "items_total": 42}
+        mock_format.return_value = []
+        view = queryMultiAdapter((self.news_view, self.request), name="seo_html")
+        view()
+        self.assertEqual(view.total, 42)
+        self.assertEqual(len(view.get_data), 0)
+
+    @patch("imio.smartweb.core.contents.rest.view.get_endpoint_data")
+    @patch("imio.smartweb.core.contents.rest.view.format_sitemap_items")
+    def test_seo_hidden_react_links_batching(self, mock_format, mock_endpoint):
+        mock_endpoint.return_value = {"items": [], "items_total": 50}
+        mock_format.return_value = []
+        self.request.form["b_start"] = "10"
+        self.request.form["b_size"] = "20"
+        view = queryMultiAdapter((self.events_view, self.request), name="seo_html")
+        view()
+        self.assertEqual(view.b_start, 10)
+        self.assertEqual(view.b_size, 20)
+        self.assertEqual(view.total, 50)
+
+
+class TestEventsViewView(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.request = self.layer["request"]
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.events_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.EventsView",
+            title="Events view",
+            id="events-view",
+        )
+
+    def _get_view(self):
+        return queryMultiAdapter((self.events_view, self.request), name="view")
+
+    def _make_event_data(self, **kwargs):
+        base = {
+            "title": "Test Event",
+            "text": "Event text",
+            "description": "A test event description",
+            "street": "Rue de la Loi",
+            "number": "16",
+            "city": "Bruxelles",
+            "zipcode": 1000,
+            "country": None,
+            "contact_phone": "+32 2 123 45 67",
+            "contact_email": None,
+            "event_url": "https://kamoulox.be/event",
+            "event_type": None,
+            "start": "2024-06-15T09:00:00",
+            "end": "2024-06-15T18:00:00",
+            "whole_day": False,
+            "geolocation": None,
+            "image": {},
+        }
+        base.update(kwargs)
+        return base
+
+    def test_formated_event_basic(self):
+        view = self._get_view()
+        data = self._make_event_data()
+        result = view._formated_event(data)
+        self.assertEqual(result["name"], "Test Event")
+        self.assertEqual(result["text"], "Event text")
+        self.assertIn("15/06/2024", result["period_text"])
+        self.assertIn("09:00", result["period_text"])
+
+    def test_formated_event_whole_day(self):
+        view = self._get_view()
+        data = self._make_event_data(whole_day=True)
+        result = view._formated_event(data)
+        self.assertIn("15/06/2024", result["period_text"])
+        # Whole day: no time in period_text
+        self.assertNotIn("09:00", result["period_text"])
+
+    def test_formated_event_with_country(self):
+        view = self._get_view()
+        data = self._make_event_data(country={"title": "Belgique", "token": "be"})
+        result = view._formated_event(data)
+        self.assertIn("Belgique", result["address"])
+
+    def test_formated_event_without_address(self):
+        view = self._get_view()
+        data = self._make_event_data(street=None, number=None, city=None, zipcode=None)
+        result = view._formated_event(data)
+        self.assertIsNone(result["address"])
+
+    def test_formated_event_with_email(self):
+        view = self._get_view()
+        data = self._make_event_data(contact_email="info@kamoulox.be")
+        result = view._formated_event(data)
+        self.assertIn("info@kamoulox.be", result["email"])
+
+    def test_formated_event_with_event_type(self):
+        view = self._get_view()
+        data = self._make_event_data(
+            event_type={"title": "Concert", "token": "concert"}
+        )
+        result = view._formated_event(data)
+        self.assertIn("Concert", result["event_type"])
+
+    def test_formated_event_with_geolocation(self):
+        view = self._get_view()
+        data = self._make_event_data(geolocation={"latitude": 50.85, "longitude": 4.35})
+        result = view._formated_event(data)
+        self.assertEqual(result["geolocation"], (50.85, 4.35))
+
+    def test_formated_event_no_geolocation(self):
+        view = self._get_view()
+        data = self._make_event_data(geolocation={"latitude": None, "longitude": None})
+        result = view._formated_event(data)
+        self.assertIsNone(result["geolocation"])
+
+    def test_formated_event_with_portrait_affiche_image(self):
+        view = self._get_view()
+        image_url = "https://kamoulox.be/@@images/image-portrait.jpeg"
+        data = self._make_event_data(
+            image={
+                "scales": {
+                    "portrait_affiche": {
+                        "download": image_url,
+                        "width": 440,
+                        "height": 782,
+                    }
+                }
+            }
+        )
+        result = view._formated_event(data)
+        self.assertEqual(result["image_url"], image_url)
+
+    def test_formated_event_with_fallback_download_image(self):
+        view = self._get_view()
+        image_url = "https://kamoulox.be/@@images/image.jpeg"
+        data = self._make_event_data(image={"download": image_url})
+        result = view._formated_event(data)
+        self.assertEqual(result["image_url"], image_url)
+
+    def test_formated_event_without_image(self):
+        view = self._get_view()
+        data = self._make_event_data(image={})
+        result = view._formated_event(data)
+        self.assertIsNone(result["image_url"])
+
+    def test_events_view_properties(self):
+        self.events_view.display_map = True
+        self.events_view.only_past_events = False
+        self.events_view.display_agendas_titles = True
+        self.events_view.show_categories_or_topics = "category"
+        view = self._get_view()
+        self.assertTrue(view.display_map)
+        self.assertFalse(view.only_past_events)
+        self.assertTrue(view.display_agendas_titles)
+        self.assertEqual(view.show_categories_or_topics, "category")
+        # propose_url is from registry - just check it doesn't raise
+        self.assertIsNone(view.propose_url)
+
+
+class TestNewsViewView(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.request = self.layer["request"]
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.news_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.NewsView",
+            title="News view",
+            id="news-view",
+        )
+
+    def _get_view(self):
+        return queryMultiAdapter((self.news_view, self.request), name="view")
+
+    def _make_news_data(self, **kwargs):
+        base = {
+            "title": "Test News",
+            "text": "News text",
+            "description": "A news description",
+            "contact_phone": "+32 2 123 45 67",
+            "contact_email": None,
+            "site_url": "https://kamoulox.be/news",
+            "image": {},
+        }
+        base.update(kwargs)
+        return base
+
+    def test_formated_news_basic(self):
+        view = self._get_view()
+        data = self._make_news_data()
+        result = view._formated_news(data)
+        self.assertEqual(result["name"], "Test News")
+        self.assertEqual(result["text"], "News text")
+        self.assertEqual(result["url"], "https://kamoulox.be/news")
+
+    def test_formated_news_with_email(self):
+        view = self._get_view()
+        data = self._make_news_data(contact_email="news@kamoulox.be")
+        result = view._formated_news(data)
+        self.assertIn("news@kamoulox.be", result["email"])
+
+    def test_formated_news_with_portrait_affiche_image(self):
+        view = self._get_view()
+        image_url = "https://kamoulox.be/@@images/image-portrait.jpeg"
+        data = self._make_news_data(
+            image={
+                "scales": {
+                    "portrait_affiche": {
+                        "download": image_url,
+                        "width": 440,
+                        "height": 782,
+                    }
+                }
+            }
+        )
+        result = view._formated_news(data)
+        self.assertEqual(result["image_url"], image_url)
+
+    def test_formated_news_with_fallback_download_image(self):
+        view = self._get_view()
+        image_url = "https://kamoulox.be/@@images/image.jpeg"
+        data = self._make_news_data(image={"download": image_url})
+        result = view._formated_news(data)
+        self.assertEqual(result["image_url"], image_url)
+
+    def test_formated_news_without_image(self):
+        view = self._get_view()
+        data = self._make_news_data(image={})
+        result = view._formated_news(data)
+        self.assertIsNone(result["image_url"])
+
+    def test_news_view_properties(self):
+        self.news_view.display_newsfolders_titles = True
+        self.news_view.show_categories_or_topics = "topic"
+        view = self._get_view()
+        self.assertTrue(view.display_newsfolders_titles)
+        self.assertEqual(view.show_categories_or_topics, "topic")
+        # propose_url from registry - just check it doesn't raise
+        self.assertIsNone(view.propose_url)
+
+
+class TestBaseNewsEndpoint(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.news_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.NewsView",
+            title="News view",
+        )
+
+    def _make_endpoint(self):
+        return NewsEndpoint(self.news_view, self.request)
+
+    def _make_item(self, with_image=False, sub_items=None):
+        item = {
+            "@id": "http://localhost:8080/Plone/news/item1",
+            "@type": "imio.news.NewsItem",
+            "modified": "2025-01-01T00:00:00+00:00",
+        }
+        if with_image:
+            item["image"] = {"scales": {}}
+        if sub_items is not None:
+            item["items"] = sub_items
+        return item
+
+    # --- __call__ ---
+
+    def test_call_returns_empty_dict_when_super_returns_none(self):
+        endpoint = self._make_endpoint()
+        with patch.object(BaseEndpoint, "__call__", return_value=None):
+            result = endpoint()
+        self.assertEqual(result, {})
+
+    def test_call_returns_results_unchanged_when_no_items(self):
+        endpoint = self._make_endpoint()
+        with patch.object(BaseEndpoint, "__call__", return_value={"items_total": 0}):
+            result = endpoint()
+        self.assertEqual(result, {"items_total": 0})
+
+    def test_call_processes_image_when_result_has_image(self):
+        endpoint = self._make_endpoint()
+        item = self._make_item(with_image=True)
+        with patch.object(BaseEndpoint, "__call__", return_value={"items": [item]}):
+            with patch.object(endpoint, "convert_cached_image_scales") as mock_convert:
+                endpoint()
+        self.assertTrue(mock_convert.called)
+        first_call_args = mock_convert.call_args_list[0][0]
+        self.assertIs(first_call_args[0], item)
+
+    def test_call_skips_image_processing_when_no_image(self):
+        endpoint = self._make_endpoint()
+        item = self._make_item(with_image=False)
+        with patch.object(BaseEndpoint, "__call__", return_value={"items": [item]}):
+            with patch.object(endpoint, "convert_cached_image_scales") as mock_convert:
+                endpoint()
+        mock_convert.assert_not_called()
+
+    def test_call_processes_sub_items_of_type_image(self):
+        endpoint = self._make_endpoint()
+        sub_item = {
+            "@id": "http://localhost:8080/Plone/news/item1/image1",
+            "@type": "Image",
+        }
+        item = self._make_item(sub_items=[sub_item])
+        with patch.object(BaseEndpoint, "__call__", return_value={"items": [item]}):
+            with patch.object(endpoint, "convert_cached_image_scales") as mock_convert:
+                endpoint()
+        self.assertTrue(mock_convert.called)
+        call_args = mock_convert.call_args_list[0][0]
+        self.assertIs(call_args[0], sub_item)
+
+    def test_call_skips_sub_items_not_of_type_image(self):
+        endpoint = self._make_endpoint()
+        sub_item = {
+            "@id": "http://localhost:8080/Plone/news/item1/file1",
+            "@type": "File",
+        }
+        item = self._make_item(sub_items=[sub_item])
+        with patch.object(BaseEndpoint, "__call__", return_value={"items": [item]}):
+            with patch.object(endpoint, "convert_cached_image_scales") as mock_convert:
+                endpoint()
+        mock_convert.assert_not_called()
+
+    def test_call_uses_context_orientation_for_main_image(self):
+        self.news_view.orientation = "portrait"
+        endpoint = self._make_endpoint()
+        item = self._make_item(with_image=True)
+        with patch.object(BaseEndpoint, "__call__", return_value={"items": [item]}):
+            with patch.object(endpoint, "convert_cached_image_scales") as mock_convert:
+                endpoint()
+        call_kwargs = mock_convert.call_args_list[0][1]
+        self.assertEqual(call_kwargs.get("orientation"), "portrait")
+
+    def test_call_returns_items_in_result(self):
+        endpoint = self._make_endpoint()
+        items = [self._make_item()]
+        with patch.object(BaseEndpoint, "__call__", return_value={"items": items}):
+            with patch.object(endpoint, "convert_cached_image_scales"):
+                result = endpoint()
+        self.assertIn("items", result)
+        self.assertEqual(len(result["items"]), 1)
+
+
+class TestGetNewsFoldersUidsAndTitle(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.news_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.NewsView",
+            title="News view",
+        )
+
+    def _make_endpoint(self):
+        return NewsEndpoint(self.news_view, self.request)
+
+    def _entity_data(self):
+        return {
+            "items": [
+                {
+                    "@id": "http://localhost:8080/Plone/manage-news",
+                    "@type": "imio.news.Entity",
+                    "UID": "entity-uid-123",
+                    "title": "Test Entity",
+                }
+            ]
+        }
+
+    def _newsfolders_data(self):
+        return {
+            "items": [
+                {"UID": "folder-uid-1", "title": "News folder : Administration"},
+                {"UID": "folder-uid-2", "title": "News Folder : CPAS"},
+            ]
+        }
+
+    def test_returns_uids_list(self):
+        endpoint = self._make_endpoint()
+        with patch(f"{_NEWS_ENDPOINT_MODULE}.get_json") as mock_get:
+            mock_get.side_effect = [self._entity_data(), self._newsfolders_data()]
+            uids, _ = endpoint._get_news_folders_uids_and_title_from_entity("some-uid")
+        self.assertEqual(uids, ["folder-uid-1", "folder-uid-2"])
+
+    def test_returns_title_dict(self):
+        endpoint = self._make_endpoint()
+        with patch(f"{_NEWS_ENDPOINT_MODULE}.get_json") as mock_get:
+            mock_get.side_effect = [self._entity_data(), self._newsfolders_data()]
+            _, data = endpoint._get_news_folders_uids_and_title_from_entity("some-uid")
+        self.assertEqual(data["folder-uid-1"], "News folder : Administration")
+        self.assertEqual(data["folder-uid-2"], "News Folder : CPAS")
+
+    def test_makes_two_get_json_calls(self):
+        endpoint = self._make_endpoint()
+        with patch(f"{_NEWS_ENDPOINT_MODULE}.get_json") as mock_get:
+            mock_get.side_effect = [self._entity_data(), self._newsfolders_data()]
+            endpoint._get_news_folders_uids_and_title_from_entity("some-uid")
+        self.assertEqual(mock_get.call_count, 2)
+
+    def test_first_call_uses_entity_uid_in_url(self):
+        endpoint = self._make_endpoint()
+        with patch(f"{_NEWS_ENDPOINT_MODULE}.get_json") as mock_get:
+            mock_get.side_effect = [self._entity_data(), self._newsfolders_data()]
+            endpoint._get_news_folders_uids_and_title_from_entity("my-entity-uid")
+        first_url = mock_get.call_args_list[0][0][0]
+        self.assertIn("my-entity-uid", first_url)
+
+
+class TestNewsEndpointQueryUrl(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.news_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.NewsView",
+            title="News view",
+        )
+        self.news_view.nb_results = 10
+        self.uids = ["folder-uid-admin", "folder-uid-cpas"]
+        self.data = {
+            "folder-uid-admin": "News folder : Administration",
+            "folder-uid-cpas": "News Folder : CPAS",
+        }
+
+    def tearDown(self):
+        self.request.form.pop("batch_size", None)
+
+    def _get_query_url(self, selected=None, batch_size=0):
+        if selected is not None:
+            self.news_view.selected_news_folder = selected
+        endpoint = NewsEndpoint(self.news_view, self.request, batch_size=batch_size)
+        with patch(f"{_NEWS_ENDPOINT_MODULE}.api") as mock_api:
+            mock_api.portal.get_registry_record.return_value = "entity-uid-123"
+            with patch(f"{_BASE_MODULE}.api") as mock_base_api:
+                mock_base_api.portal.get_current_language.return_value = "fr"
+                with patch.object(
+                    endpoint,
+                    "_get_news_folders_uids_and_title_from_entity",
+                    return_value=(self.uids, self.data),
+                ):
+                    return endpoint.query_url
+
+    def test_uses_selected_folder_when_in_uids(self):
+        url = self._get_query_url(selected="folder-uid-cpas")
+        self.assertIn("folder-uid-cpas", url)
+
+    def test_falls_back_to_administration_folder_when_selected_not_in_uids(self):
+        url = self._get_query_url(selected="unknown-uid")
+        self.assertIn("folder-uid-admin", url)
+
+    def test_falls_back_to_first_uid_when_no_administration_folder(self):
+        self.uids = ["folder-uid-1", "folder-uid-2"]
+        self.data = {
+            "folder-uid-1": "News Folder : CPAS",
+            "folder-uid-2": "News Folder : OCMW",
+        }
+        url = self._get_query_url(selected="unknown-uid")
+        self.assertIn("folder-uid-1", url)
+
+    def test_batch_size_from_request_form(self):
+        self.request.form["batch_size"] = "5"
+        url = self._get_query_url(selected=self.uids[0])
+        self.assertIn("b_size=5", url)
+
+    def test_batch_size_uses_context_nb_results_when_endpoint_batch_size_zero(self):
+        self.news_view.nb_results = 15
+        url = self._get_query_url(selected=self.uids[0], batch_size=0)
+        self.assertIn("b_size=15", url)
+
+    def test_batch_size_from_endpoint_when_non_zero(self):
+        url = self._get_query_url(selected=self.uids[0], batch_size=7)
+        self.assertIn("b_size=7", url)
+
+    def test_query_url_contains_remote_endpoint(self):
+        url = self._get_query_url(selected=self.uids[0])
+        self.assertIn("@search_newsitems", url)
+
+    def test_news_filters_query_url_contains_filters_endpoint(self):
+        endpoint = NewsFiltersEndpoint(self.news_view, self.request)
+        self.news_view.selected_news_folder = self.uids[0]
+        with patch(f"{_NEWS_ENDPOINT_MODULE}.api") as mock_api:
+            mock_api.portal.get_registry_record.return_value = "entity-uid-123"
+            with patch(f"{_BASE_MODULE}.api") as mock_base_api:
+                mock_base_api.portal.get_current_language.return_value = "fr"
+                with patch.object(
+                    endpoint,
+                    "_get_news_folders_uids_and_title_from_entity",
+                    return_value=(self.uids, self.data),
+                ):
+                    url = endpoint.query_url
+        self.assertIn("@search-filters", url)
+
+    def test_query_url_contains_entity_uid(self):
+        url = self._get_query_url(selected=self.uids[0])
+        self.assertIn("entity-uid-123", url)
+
+
+class TestNewsEndpointGetService(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.news_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.NewsView",
+            title="News view",
+        )
+
+    def _make_service(self, cls):
+        service = object.__new__(cls)
+        service.context = self.news_view
+        service.request = self.request
+        return service
+
+    def test_reply_calls_news_endpoint_and_returns_result(self):
+        service = self._make_service(NewsEndpointGet)
+        expected = {"items": [], "items_total": 0}
+        with patch.object(NewsEndpoint, "__call__", return_value=expected):
+            result = service.reply()
+        self.assertEqual(result, expected)
+
+    def test_reply_for_given_object_uses_given_context(self):
+        service = self._make_service(NewsEndpointGet)
+        other_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.NewsView",
+            title="Other News view",
+        )
+        captured = []
+
+        def capture_call(self_ep):
+            captured.append(self_ep.context)
+            return {}
+
+        with patch.object(NewsEndpoint, "__call__", capture_call):
+            service.reply_for_given_object(other_view, self.request)
+        self.assertIs(captured[0], other_view)
+
+    def test_reply_for_given_object_passes_batch_size(self):
+        service = self._make_service(NewsEndpointGet)
+        captured = []
+
+        def capture_call(self_ep):
+            captured.append(self_ep.batch_size)
+            return {}
+
+        with patch.object(NewsEndpoint, "__call__", capture_call):
+            service.reply_for_given_object(self.news_view, self.request, batch_size=8)
+        self.assertEqual(captured[0], 8)
+
+    def test_reply_for_given_object_passes_fullobjects(self):
+        service = self._make_service(NewsEndpointGet)
+        captured = []
+
+        def capture_call(self_ep):
+            captured.append(self_ep.fullobjects)
+            return {}
+
+        with patch.object(NewsEndpoint, "__call__", capture_call):
+            service.reply_for_given_object(self.news_view, self.request, fullobjects=0)
+        self.assertEqual(captured[0], 0)
+
+    def test_news_filters_reply_calls_filters_endpoint(self):
+        service = self._make_service(NewsFiltersEndpointGet)
+        expected = {"filters": []}
+        with patch.object(NewsFiltersEndpoint, "__call__", return_value=expected):
+            result = service.reply()
+        self.assertEqual(result, expected)
+
+
+class TestDirectoryViewView(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.request = self.layer["request"]
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.directory_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.DirectoryView",
+            title="Directory view",
+            id="directory-view",
+        )
+
+    def _get_view(self):
+        return queryMultiAdapter((self.directory_view, self.request), name="view")
+
+    def _make_contact_data(self, **kwargs):
+        # NOTE: "type" key is intentionally omitted from the base dict.
+        # data.get("type", {}).get("title") raises AttributeError if type=None.
+        base = {
+            "title": "Test Contact",
+            "subtitle": None,
+            "number": "1",
+            "street": "Rue de la Paix",
+            "city": "Namur",
+            "zipcode": 5000,
+            "country": None,
+            "phones": [],
+            "mails": [],
+            "urls": [],
+            "description": None,
+            "taxonomy_contact_category": [],
+            "geolocation": {},
+            "image": {},
+        }
+        base.update(kwargs)
+        return base
+
+    # --- _formated_contact: name ---
+
+    def test_formated_contact_basic_name(self):
+        view = self._get_view()
+        data = self._make_contact_data()
+        result = view._formated_contact(data)
+        self.assertEqual(result["name"], "Test Contact")
+
+    def test_formated_contact_language_specific_title_takes_priority(self):
+        view = self._get_view()
+        data = self._make_contact_data(title="Fallback", title_fr="French Title")
+        with patch(f"{_DIR_VIEW_MODULE}.api") as mock_api:
+            mock_api.portal.get_current_language.return_value = "fr"
+            result = view._formated_contact(data)
+        self.assertEqual(result["name"], "French Title")
+
+    def test_formated_contact_falls_back_to_title_when_lang_specific_missing(self):
+        view = self._get_view()
+        data = self._make_contact_data(title="Fallback Title")
+        with patch(f"{_DIR_VIEW_MODULE}.api") as mock_api:
+            mock_api.portal.get_current_language.return_value = "nl"
+            result = view._formated_contact(data)
+        self.assertEqual(result["name"], "Fallback Title")
+
+    # --- _formated_contact: subtitle ---
+
+    def test_formated_contact_subtitle(self):
+        view = self._get_view()
+        data = self._make_contact_data(subtitle="A subtitle")
+        result = view._formated_contact(data)
+        self.assertEqual(result["subtitle"], "A subtitle")
+
+    # --- _formated_contact: phones ---
+
+    def test_formated_contact_with_phone(self):
+        view = self._get_view()
+        data = self._make_contact_data(phones=[{"number": "+32 81 12 34 56"}])
+        result = view._formated_contact(data)
+        self.assertEqual(result["phone"], "+32 81 12 34 56")
+
+    def test_formated_contact_without_phone(self):
+        view = self._get_view()
+        data = self._make_contact_data(phones=[])
+        result = view._formated_contact(data)
+        self.assertIsNone(result["phone"])
+
+    # --- _formated_contact: mails ---
+
+    def test_formated_contact_with_email(self):
+        view = self._get_view()
+        data = self._make_contact_data(mails=[{"mail_address": "info@namur.be"}])
+        result = view._formated_contact(data)
+        self.assertIn("info@namur.be", result["email"])
+
+    def test_formated_contact_without_email(self):
+        view = self._get_view()
+        data = self._make_contact_data(mails=[])
+        result = view._formated_contact(data)
+        self.assertIsNone(result["email"])
+
+    # --- _formated_contact: urls ---
+
+    def test_formated_contact_with_url(self):
+        view = self._get_view()
+        data = self._make_contact_data(urls=[{"url": "https://namur.be"}])
+        result = view._formated_contact(data)
+        self.assertEqual(result["url"], "https://namur.be")
+
+    def test_formated_contact_without_url(self):
+        view = self._get_view()
+        data = self._make_contact_data(urls=[])
+        result = view._formated_contact(data)
+        self.assertIsNone(result["url"])
+
+    # --- _formated_contact: description ---
+
+    def test_formated_contact_with_description(self):
+        view = self._get_view()
+        data = self._make_contact_data(description="A nice description")
+        result = view._formated_contact(data)
+        self.assertIn("A nice description", result["description"])
+
+    def test_formated_contact_without_description(self):
+        view = self._get_view()
+        data = self._make_contact_data(description=None)
+        result = view._formated_contact(data)
+        self.assertIsNone(result["description"])
+
+    # --- _formated_contact: category ---
+
+    def test_formated_contact_with_category(self):
+        view = self._get_view()
+        data = self._make_contact_data(
+            taxonomy_contact_category=[{"title": "Library", "token": "library"}]
+        )
+        result = view._formated_contact(data)
+        self.assertIn("Library", result["category"])
+
+    def test_formated_contact_without_category(self):
+        view = self._get_view()
+        data = self._make_contact_data(taxonomy_contact_category=[])
+        result = view._formated_contact(data)
+        self.assertIsNone(result["category"])
+
+    # --- _formated_contact: contact_type ---
+
+    def test_formated_contact_with_contact_type(self):
+        view = self._get_view()
+        data = self._make_contact_data(type={"title": "School", "token": "school"})
+        result = view._formated_contact(data)
+        self.assertIn("School", result["contact_type"])
+
+    def test_formated_contact_without_contact_type(self):
+        view = self._get_view()
+        # "type" key intentionally absent from base dict — defaults to {}
+        data = self._make_contact_data()
+        result = view._formated_contact(data)
+        self.assertIsNone(result["contact_type"])
+
+    # --- _formated_contact: geolocation ---
+
+    def test_formated_contact_with_geolocation(self):
+        view = self._get_view()
+        data = self._make_contact_data(
+            geolocation={"latitude": 50.46, "longitude": 4.86}
+        )
+        result = view._formated_contact(data)
+        self.assertEqual(result["geolocation"], (50.46, 4.86))
+
+    def test_formated_contact_without_geolocation(self):
+        view = self._get_view()
+        data = self._make_contact_data(geolocation=None)
+        result = view._formated_contact(data)
+        self.assertIsNone(result["geolocation"])
+
+    # --- _formated_contact: image ---
+
+    def test_formated_contact_with_portrait_affiche_image(self):
+        view = self._get_view()
+        image_url = "https://directory.be/@@images/image-portrait.jpeg"
+        data = self._make_contact_data(
+            image={
+                "scales": {
+                    "portrait_affiche": {
+                        "download": image_url,
+                        "width": 440,
+                        "height": 782,
+                    }
+                }
+            }
+        )
+        result = view._formated_contact(data)
+        self.assertEqual(result["image_url"], image_url)
+
+    def test_formated_contact_with_fallback_download_image(self):
+        view = self._get_view()
+        image_url = "https://directory.be/@@images/image.jpeg"
+        data = self._make_contact_data(image={"download": image_url})
+        result = view._formated_contact(data)
+        self.assertEqual(result["image_url"], image_url)
+
+    def test_formated_contact_without_image(self):
+        view = self._get_view()
+        data = self._make_contact_data(image={})
+        result = view._formated_contact(data)
+        self.assertIsNone(result["image_url"])
+
+    # --- _formated_contact: address ---
+
+    def test_formated_contact_with_country_in_address(self):
+        view = self._get_view()
+        data = self._make_contact_data(country={"title": "Belgique", "token": "be"})
+        result = view._formated_contact(data)
+        self.assertIn("Belgique", result["address"])
+
+    def test_formated_contact_without_address_fields(self):
+        view = self._get_view()
+        data = self._make_contact_data(
+            street=None, number=None, city=None, zipcode=None
+        )
+        result = view._formated_contact(data)
+        self.assertIsNone(result["address"])
+
+    # --- properties ---
+
+    def test_display_map_property(self):
+        self.directory_view.display_map = True
+        view = self._get_view()
+        self.assertTrue(view.display_map)
+
+    def test_propose_url_from_registry(self):
+        view = self._get_view()
+        # Registry record not configured in tests — returns None
+        self.assertIsNone(view.propose_url)
+
+    def test_contact_property_uses_item(self):
+        view = self._get_view()
+        item_data = self._make_contact_data(title="My Contact")
+        view._item = {"items": [item_data]}
+        result = view.contact
+        self.assertEqual(result["name"], "My Contact")

--- a/src/imio/smartweb/core/tests/test_search_endpoint.py
+++ b/src/imio/smartweb/core/tests/test_search_endpoint.py
@@ -1,0 +1,416 @@
+# -*- coding: utf-8 -*-
+
+from imio.smartweb.core import config
+from imio.smartweb.core.contents.rest.search.endpoint import _cache_key
+from imio.smartweb.core.contents.rest.search.endpoint import ExtendedSearchHandler
+from imio.smartweb.core.contents.rest.search.endpoint import get_default_view_url
+from imio.smartweb.core.contents.rest.search.endpoint import get_events_views
+from imio.smartweb.core.contents.rest.search.endpoint import get_navigation_root
+from imio.smartweb.core.contents.rest.search.endpoint import get_news_views
+from imio.smartweb.core.contents.rest.search.endpoint import get_views_mapping
+from imio.smartweb.core.contents.rest.search.endpoint import SearchGet
+from imio.smartweb.core.testing import IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+from imio.smartweb.core.testing import ImioSmartwebTestCase
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.restapi.search.handler import SearchHandler
+from plone.uuid.interfaces import IUUID
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from zope.component import queryMultiAdapter
+
+
+class TestSearchEndpointHelpers(ImioSmartwebTestCase):
+    """Tests for helper functions in search/endpoint.py"""
+
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def test_cache_key_with_uid(self):
+        key = _cache_key(None, self.portal)
+        self.assertIsInstance(key, tuple)
+        self.assertEqual(len(key), 2)
+        self.assertNotEqual(key[0], "PloneSite")
+
+    def test_cache_key_without_uid(self):
+        class NoUID:
+            pass
+
+        key = _cache_key(None, NoUID())
+        self.assertEqual(key[0], "PloneSite")
+
+    def test_get_news_views_empty(self):
+        views = get_news_views(self.portal)
+        self.assertIsInstance(views, dict)
+
+    def test_get_events_views_empty(self):
+        views = get_events_views(self.portal)
+        self.assertIsInstance(views, dict)
+
+    def test_get_navigation_root_is_navigation_root(self):
+        result = get_navigation_root(self.portal)
+        self.assertEqual(result, self.portal)
+
+    def test_get_navigation_root_traverses_chain(self):
+        page = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.Page",
+            id="test-nav-page",
+        )
+        result = get_navigation_root(page)
+        self.assertEqual(result, self.portal)
+
+    def test_get_default_view_url_not_set(self):
+        result = get_default_view_url("events")
+        self.assertEqual(result, "")
+
+    def test_get_default_view_url_uid_not_found(self):
+        with patch(
+            "imio.smartweb.core.contents.rest.search.endpoint.api.portal.get_registry_record",
+            return_value="00000000000000000000000000000099",
+        ):
+            result = get_default_view_url("events")
+            self.assertEqual(result, "")
+
+    def test_get_default_view_url_with_valid_uid(self):
+        events_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.EventsView",
+            id="test-events-view",
+        )
+        uid = IUUID(events_view)
+        with patch(
+            "imio.smartweb.core.contents.rest.search.endpoint.api.portal.get_registry_record",
+            return_value=uid,
+        ):
+            result = get_default_view_url("events")
+            self.assertEqual(result, events_view.absolute_url())
+
+    def test_get_views_mapping_structure(self):
+        mapping = get_views_mapping(self.portal)
+        self.assertIn("imio.news.NewsItem", mapping)
+        self.assertIn("imio.events.Event", mapping)
+        self.assertIn("imio.directory.Contact", mapping)
+        self.assertIn("default", mapping["imio.news.NewsItem"])
+        self.assertIn("default", mapping["imio.events.Event"])
+        self.assertIn("default", mapping["imio.directory.Contact"])
+
+
+class TestExtendedSearchHandler(ImioSmartwebTestCase):
+    """Tests for ExtendedSearchHandler methods"""
+
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def test_navigation_root_property(self):
+        page = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.Page",
+            id="test-search-page",
+        )
+        handler = ExtendedSearchHandler(page, self.request)
+        self.assertEqual(handler._navigation_root, self.portal)
+
+    def test_update_metadata_fields_string_original(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        result = handler._update_metadata_fields(
+            "existing_field", ["new_field", "existing_field"]
+        )
+        self.assertIn("existing_field", result)
+        self.assertIn("new_field", result)
+        self.assertEqual(result.count("existing_field"), 1)
+
+    def test_update_metadata_fields_list_original(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        result = handler._update_metadata_fields(
+            ["field1", "field2"], ["field2", "field3"]
+        )
+        self.assertIn("field1", result)
+        self.assertIn("field2", result)
+        self.assertIn("field3", result)
+        self.assertEqual(result.count("field2"), 1)
+
+    def test_get_source_url_news(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        url = handler._get_source_url("/plone/news/item", "news")
+        self.assertIn(config.NEWS_URL, url)
+        self.assertIn("news/item", url)
+
+    def test_get_source_url_events(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        url = handler._get_source_url("/plone/events/item", "events")
+        self.assertIn(config.EVENTS_URL, url)
+
+    def test_get_source_url_directory(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        url = handler._get_source_url("/plone/directory/contact", "directory")
+        self.assertIn(config.DIRECTORY_URL, url)
+
+    def test_get_source_url_unknown_core(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        url = handler._get_source_url("/plone/content/item", "unknown")
+        self.assertIn("content/item", url)
+
+    def test_core_query_news(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        params = handler._core_query("news")
+        self.assertIsNotNone(params)
+        self.assertEqual(params["portal_type"], ["imio.news.NewsItem"])
+        self.assertIn("selected_news_folders", params)
+
+    def test_core_query_events(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        params = handler._core_query("events")
+        self.assertIsNotNone(params)
+        self.assertEqual(params["portal_type"], ["imio.events.Event"])
+        self.assertIn("selected_agendas", params)
+
+    def test_core_query_directory(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        params = handler._core_query("directory")
+        self.assertIsNotNone(params)
+        self.assertEqual(params["portal_type"], ["imio.directory.Contact"])
+        self.assertIn("selected_entities", params)
+
+    def test_core_query_unknown_returns_none(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        params = handler._core_query("unknown")
+        self.assertIsNone(params)
+
+    def test_core_query_with_non_fr_language_adds_translated_fields(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        params = handler._core_query("news", language="nl")
+        self.assertIn("title_nl", params["metadata_fields"])
+        self.assertIn("description_nl", params["metadata_fields"])
+        self.assertTrue(params.get("translated_in_nl"))
+
+    def test_adapt_result_values_unknown_type_passthrough(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        item = {"@type": "unknown.Type", "UID": "uid"}
+        mapping = {"imio.news.NewsItem": {"default": ""}}
+        result = handler._adapt_result_values(item, mapping, "news")
+        self.assertEqual(result, item)
+
+    def test_adapt_result_values_known_type_adds_urls(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        item = {
+            "@type": "imio.news.NewsItem",
+            "container_uid": "some-uid",
+            "UID": "item-uid",
+            "path_string": "/plone/news/item",
+            "modified": "2021-09-14T08:00:00",
+        }
+        mapping = {"imio.news.NewsItem": {"default": "http://nohost/plone/news-view"}}
+        result = handler._adapt_result_values(item, mapping, "news")
+        self.assertIn("_url", result)
+        self.assertIn("item-uid", result["_url"])
+        self.assertIn("_source_url", result)
+        self.assertIn("image_url", result)
+
+    def test_adapt_result_values_uses_container_uid_when_matched(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        item = {
+            "@type": "imio.news.NewsItem",
+            "container_uid": "folder-uid",
+            "UID": "item-uid",
+            "path_string": "/plone/news/item",
+            "modified": "2021-09-14T08:00:00",
+        }
+        mapping = {
+            "imio.news.NewsItem": {
+                "folder-uid": "http://nohost/plone/specific-view",
+                "default": "http://nohost/plone/default-view",
+            }
+        }
+        result = handler._adapt_result_values(item, mapping, "news")
+        self.assertIn("specific-view", result["_url"])
+
+    def test_adapt_result_values_translates_fields_for_non_fr_language(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        item = {
+            "@type": "imio.news.NewsItem",
+            "container_uid": "some-uid",
+            "UID": "item-uid",
+            "path_string": "/plone/news/item",
+            "modified": "2021-09-14T08:00:00",
+            "title_nl": "Dutch title",
+            "description_nl": "Dutch description",
+        }
+        mapping = {"imio.news.NewsItem": {"default": "http://nohost/plone/news-view"}}
+        result = handler._adapt_result_values(item, mapping, "news", language="nl")
+        self.assertEqual(result["title"], "Dutch title")
+        self.assertEqual(result["description"], "Dutch description")
+        self.assertNotIn("title_nl", result)
+        self.assertNotIn("description_nl", result)
+
+    def test_adapt_result_loops_items(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        mock_result = {
+            "items": [
+                {
+                    "@type": "imio.news.NewsItem",
+                    "container_uid": "some-uid",
+                    "UID": "item-uid",
+                    "path_string": "/plone/news/item",
+                    "modified": "2021-09-14T08:00:00",
+                }
+            ],
+            "items_total": 1,
+        }
+        result = handler._adapt_result(mock_result, "news")
+        self.assertEqual(len(result["items"]), 1)
+        self.assertIn("_url", result["items"][0])
+
+    def test_adapt_result_empty_items(self):
+        handler = ExtendedSearchHandler(self.portal, self.request)
+        mock_result = {"items": [], "items_total": 0}
+        result = handler._adapt_result(mock_result, "news")
+        self.assertEqual(result["items"], [])
+
+    def test_search_basic_no_core(self):
+        mock_result = {
+            "items": [],
+            "items_total": 0,
+            "@id": "http://nohost/plone/@search",
+        }
+        with patch.object(SearchHandler, "search", return_value=mock_result):
+            handler = ExtendedSearchHandler(self.portal, self.request)
+            result = handler.search({"SearchableText": "test"})
+            self.assertEqual(result, mock_result)
+
+    def test_search_with_existing_use_site_search_settings(self):
+        mock_result = {"items": [], "items_total": 0}
+        with patch.object(SearchHandler, "search", return_value=mock_result):
+            handler = ExtendedSearchHandler(self.portal, self.request)
+            result = handler.search({"use_site_search_settings": True})
+            self.assertEqual(result, mock_result)
+
+    def test_search_with_existing_use_solr_false(self):
+        mock_result = {"items": [], "items_total": 0}
+        with patch.object(SearchHandler, "search", return_value=mock_result):
+            handler = ExtendedSearchHandler(self.portal, self.request)
+            result = handler.search({"use_solr": False})
+            self.assertEqual(result, mock_result)
+
+    def test_search_with_core_news(self):
+        mock_result = {"items": [], "items_total": 0}
+        with patch.object(SearchHandler, "search", return_value=mock_result):
+            handler = ExtendedSearchHandler(self.portal, self.request)
+            result = handler.search({"_core": "news"})
+            self.assertIsNotNone(result)
+
+    def test_search_with_core_events(self):
+        mock_result = {"items": [], "items_total": 0}
+        with patch.object(SearchHandler, "search", return_value=mock_result):
+            handler = ExtendedSearchHandler(self.portal, self.request)
+            result = handler.search({"_core": "events"})
+            self.assertIsNotNone(result)
+
+    def test_search_with_core_and_metadata_fields(self):
+        mock_result = {"items": [], "items_total": 0}
+        with patch.object(SearchHandler, "search", return_value=mock_result):
+            handler = ExtendedSearchHandler(self.portal, self.request)
+            result = handler.search({"_core": "news", "metadata_fields": ["my_field"]})
+            self.assertIsNotNone(result)
+
+    def test_search_with_core_non_fr_language_and_searchable_text(self):
+        mock_result = {"items": [], "items_total": 0}
+        with patch(
+            "imio.smartweb.core.contents.rest.search.endpoint.api.portal.get_current_language",
+            return_value="nl",
+        ):
+            with patch.object(SearchHandler, "search", return_value=mock_result):
+                handler = ExtendedSearchHandler(self.portal, self.request)
+                result = handler.search(
+                    {"_core": "news", "SearchableText": "test query"}
+                )
+                self.assertIsNotNone(result)
+
+    def test_search_with_unknown_core_skips_adapt(self):
+        mock_result = {"items": [], "items_total": 0}
+        with patch.object(SearchHandler, "search", return_value=mock_result):
+            handler = ExtendedSearchHandler(self.portal, self.request)
+            # Unknown core means _core_query returns None → no query update → no "core" key
+            result = handler.search({"_core": "unknown"})
+            self.assertEqual(result, mock_result)
+
+
+class TestSearchGet(ImioSmartwebTestCase):
+    """Tests for SearchGet REST service"""
+
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def test_search_get_reply(self):
+        mock_result = {"items": [], "items_total": 0}
+        with patch.object(ExtendedSearchHandler, "search", return_value=mock_result):
+            service = SearchGet()
+            service.context = self.portal
+            service.request = self.request
+            self.request.form = {"SearchableText": "test"}
+            result = service.reply()
+            self.assertEqual(result, mock_result)
+
+
+class TestSearchBrowserView(ImioSmartwebTestCase):
+    """Tests for Search browser view in browser/search/search.py"""
+
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def _get_search_view(self):
+        return queryMultiAdapter((self.portal, self.request), name="search")
+
+    def test_results_news(self):
+        self.request.form["SearchableText"] = "kamoulox"
+        search = self._get_search_view()
+        results = search.results_news()
+        self.assertIsNotNone(results)
+
+    def test_get_item_url_unknown_type_raises(self):
+        search = self._get_search_view()
+        item = MagicMock()
+        item.portal_type = "unknown.portal.type"
+        with self.assertRaises(NotImplementedError):
+            search.get_item_url(item)
+
+    def test_get_item_url_no_view_raises(self):
+        search = self._get_search_view()
+        item = MagicMock()
+        item.portal_type = "imio.news.NewsItem"
+        # No NewsView in catalog → should raise ValueError
+        with self.assertRaises(ValueError):
+            search.get_item_url(item)
+
+    def test_get_item_url_with_news_view(self):
+        search = self._get_search_view()
+        news_view = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.NewsView",
+            id="test-news-view-search",
+        )
+        api.content.transition(news_view, "publish")
+        item = MagicMock()
+        item.portal_type = "imio.news.NewsItem"
+        item.Title = "My News Item"
+        item.UID = "abc123"
+        url = search.get_item_url(item)
+        self.assertIn(news_view.absolute_url(), url)
+        self.assertIn("abc123", url)

--- a/src/imio/smartweb/core/tests/test_section_external_content.py
+++ b/src/imio/smartweb/core/tests/test_section_external_content.py
@@ -1,12 +1,53 @@
 # -*- coding: utf-8 -*-
 
+from imio.smartweb.core.contents.sections.external_content.views import ArcgisPlugin
+from imio.smartweb.core.contents.sections.external_content.views import ArcgisView
+from imio.smartweb.core.contents.sections.external_content.views import BasePlugin
+from imio.smartweb.core.contents.sections.external_content.views import (
+    CognitoformPlugin,
+)
+from imio.smartweb.core.contents.sections.external_content.views import EaglebePlugin
+from imio.smartweb.core.contents.sections.external_content.views import EllohaPlugin
+from imio.smartweb.core.contents.sections.external_content.views import GiveADayPlugin
+from imio.smartweb.core.contents.sections.external_content.views import (
+    IdeluxWastePlugin,
+)
+from imio.smartweb.core.contents.sections.external_content.views import (
+    IIdeluxWastePlugin,
+)
+from imio.smartweb.core.contents.sections.external_content.views import (
+    InbwContainersAffluencePlugin,
+)
+from imio.smartweb.core.contents.sections.external_content.views import (
+    IInbwContainersAffluencePlugin,
+)
+from imio.smartweb.core.contents.sections.external_content.views import (
+    IOdwbWidgetPlugin,
+)
+from imio.smartweb.core.contents.sections.external_content.views import OdwbWidgetPlugin
+from imio.smartweb.core.contents.sections.external_content.views import (
+    UnknowServicePlugin,
+)
 from imio.smartweb.core.interfaces import IOdwbViewUtils
 from imio.smartweb.core.testing import IMIO_SMARTWEB_CORE_FUNCTIONAL_TESTING
+from imio.smartweb.core.testing import IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
 from imio.smartweb.core.testing import ImioSmartwebTestCase
+from imio.smartweb.core.viewlets.external_content import ArcgisHeaderViewlet
+from imio.smartweb.core.viewlets.external_content import OdwbWidgetHeaderViewlet
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from urllib.parse import urlparse
 from zope.component import queryMultiAdapter
+
+import requests
+import requests_mock as requests_mock_module
+import unittest
+
+
+_VIEWS_MODULE = "imio.smartweb.core.contents.sections.external_content.views"
 
 
 class TestSectionExternalContent(ImioSmartwebTestCase):
@@ -128,3 +169,445 @@ class TestSectionExternalContent(ImioSmartwebTestCase):
         section_view = queryMultiAdapter((sec, self.request), name="view")
         result = '<div class="elloha elloha_error">With an elloha plugin, extra params must contain a dictionary with two keys : ConstellationWidgetContainer, Idoi</div>'
         self.assertEqual(section_view.contents, result)
+
+    def test_cognitoform_plugin(self):
+        sec = api.content.create(
+            container=self.page, type="imio.smartweb.SectionExternalContent", id="sec"
+        )
+        url = "https://www.cognitoforms.com/YourOrg/YourForm"
+        sec.external_content_url = url
+
+        # Without extra params → returns simple iframe
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn(f'<iframe src="{url}"', section_view.contents)
+        self.assertIn("overflow: auto;", section_view.contents)
+
+        # Bad format (no braces)
+        sec.external_content_params = "scrolling=yes"
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn("cognitoform_error", section_view.contents)
+
+        # Bad JSON
+        sec.external_content_params = '{"scrolling": "yes"'
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn("cognitoform_error", section_view.contents)
+
+        # Missing overflow key
+        sec.external_content_params = '{"scrolling": "yes"}'
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn("cognitoform_error", section_view.contents)
+
+        # Valid params
+        sec.external_content_params = '{"scrolling": "yes", "overflow": "hidden"}'
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn("overflow: hidden;", section_view.contents)
+        self.assertIn('scrolling="yes"', section_view.contents)
+
+    def test_arcgis_plugin(self):
+        sec = api.content.create(
+            container=self.page, type="imio.smartweb.SectionExternalContent", id="sec"
+        )
+        sec.external_content_url = "https://www.arcgis.com/apps/mapviewer/index.html"
+
+        # Without extra params → error
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn("arcgis_error", section_view.contents)
+
+        # Bad format
+        sec.external_content_params = "no braces here"
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn("arcgis_error", section_view.contents)
+
+        # Bad JSON
+        sec.external_content_params = '{"portal_item_id": "abc'
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn("arcgis_error", section_view.contents)
+
+        # Missing portal_item_id
+        sec.external_content_params = '{"other_key": "value"}'
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn("arcgis_error", section_view.contents)
+
+        # Valid portal_item_id
+        sec.external_content_params = (
+            '{"portal_item_id": "27a432b0835149e6acd3ac39d0e4349c"}'
+        )
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn(
+            "view_arcgis?portal_item_id=27a432b0835149e6acd3ac39d0e4349c",
+            section_view.contents,
+        )
+
+    def test_giveaday_plugin(self):
+        sec = api.content.create(
+            container=self.page, type="imio.smartweb.SectionExternalContent", id="sec"
+        )
+        sec.external_content_url = "https://www.giveaday.be/campaign/123"
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIn("giveaday-widget", section_view.contents)
+        self.assertIn("giveaday_v1.js", section_view.contents)
+
+    def test_idelux_waste_plugin(self):
+        sec = api.content.create(
+            container=self.page, type="imio.smartweb.SectionExternalContent", id="sec"
+        )
+        odwb_url = "https://www.odwb.be/api/explore/v2.1/catalog/datasets/guide-de-tri1/records"
+        sec.external_content_url = odwb_url
+        mock_data = {"results": [{"material": "plastic", "bin": "yellow"}]}
+
+        with requests_mock_module.Mocker() as m:
+            m.get(f"{odwb_url}?limit=-1", json=mock_data)
+            section_view = queryMultiAdapter((sec, self.request), name="view")
+            result = section_view.contents
+            self.assertEqual(result, mock_data)
+            self.assertTrue(IIdeluxWastePlugin.providedBy(section_view.get_plugin()))
+            self.assertEqual(section_view.which_plugin(), "ideluxwasteplugin")
+
+    def test_inbw_containers_affluence_plugin(self):
+        sec = api.content.create(
+            container=self.page, type="imio.smartweb.SectionExternalContent", id="sec"
+        )
+        odwb_url = "https://www.odwb.be/api/explore/v2.1/catalog/datasets/affluence/records?dataset=affluence"
+        sec.external_content_url = odwb_url
+        mock_data = {"results": [{"location": "site-a", "level": "high"}]}
+
+        with requests_mock_module.Mocker() as m:
+            m.get(f"{odwb_url}&limit=-1", json=mock_data)
+            section_view = queryMultiAdapter((sec, self.request), name="view")
+            import json
+
+            result = section_view.contents
+            self.assertEqual(result, json.dumps(mock_data))
+            self.assertTrue(
+                IInbwContainersAffluencePlugin.providedBy(section_view.get_plugin())
+            )
+            self.assertEqual(
+                section_view.which_plugin(), "inbwcontainersaffluenceplugin"
+            )
+
+    def test_odwb_widget_plugin(self):
+        sec = api.content.create(
+            container=self.page, type="imio.smartweb.SectionExternalContent", id="sec"
+        )
+        sec.external_content_url = (
+            "https://static.opendatasoft.com/ods-widgets/my-widget"
+        )
+        sec.external_content_params = "<ods-dataset-context>...</ods-dataset-context>"
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertEqual(
+            section_view.contents, "<ods-dataset-context>...</ods-dataset-context>"
+        )
+        self.assertTrue(IOdwbWidgetPlugin.providedBy(section_view.get_plugin()))
+        self.assertTrue(section_view.display_odwb_widget_viewlet())
+        self.assertEqual(section_view.which_plugin(), "odwbwidgetplugin")
+
+    def test_external_content_view_methods(self):
+        sec = api.content.create(
+            container=self.page, type="imio.smartweb.SectionExternalContent", id="sec"
+        )
+        # Non-special URL → which_plugin returns None, display_odwb_widget_viewlet False
+        sec.external_content_url = "https://kamoulox.be"
+        section_view = queryMultiAdapter((sec, self.request), name="view")
+        self.assertIsNone(section_view.which_plugin())
+        self.assertFalse(section_view.display_odwb_widget_viewlet())
+
+        # has_leadimage → False (SectionExternalContent has no lead image by default)
+        self.assertFalse(section_view.has_leadimage())
+
+        # image → returns absolute_url + download path
+        image_url = section_view.image()
+        self.assertIn(sec.absolute_url(), image_url)
+        self.assertIn("@@download/image", image_url)
+
+
+class TestArcgisHeaderViewlet(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def _make_viewlet(self, view=None):
+        return ArcgisHeaderViewlet(self.portal, self.request, view or MagicMock(), None)
+
+    def test_update_calls_parent_and_sets_setheader(self):
+        """update() delegates to parent which binds self.setHeader from the response."""
+        viewlet = self._make_viewlet()
+        viewlet.update()
+        self.assertTrue(hasattr(viewlet, "setHeader"))
+        self.assertEqual(viewlet.setHeader, self.request.response.setHeader)
+
+    def test_update_sets_portal_state(self):
+        """update() runs ViewletBase.update() which sets portal_state."""
+        viewlet = self._make_viewlet()
+        viewlet.update()
+        self.assertTrue(hasattr(viewlet, "portal_state"))
+
+
+class TestOdwbWidgetHeaderViewlet(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def _make_viewlet(self, view=None):
+        return OdwbWidgetHeaderViewlet(
+            self.portal, self.request, view or MagicMock(), None
+        )
+
+    # --- should_render ---
+
+    def test_should_render_false_when_view_has_no_attribute(self):
+        view = MagicMock(spec=[])  # no attributes → hasattr returns False
+        viewlet = self._make_viewlet(view=view)
+        self.assertFalse(viewlet.should_render())
+
+    def test_should_render_returns_true_when_view_attribute_is_true(self):
+        view = MagicMock()
+        view.should_display_odwb_widget_viewlet = True
+        viewlet = self._make_viewlet(view=view)
+        self.assertTrue(viewlet.should_render())
+
+    def test_should_render_returns_false_when_view_attribute_is_false(self):
+        view = MagicMock()
+        view.should_display_odwb_widget_viewlet = False
+        viewlet = self._make_viewlet(view=view)
+        self.assertFalse(viewlet.should_render())
+
+    # --- render ---
+
+    def test_render_calls_index_and_returns_its_result(self):
+        viewlet = self._make_viewlet()
+        viewlet.index = MagicMock(return_value="<script>odwb</script>")
+        result = viewlet.render()
+        viewlet.index.assert_called_once()
+        self.assertEqual(result, "<script>odwb</script>")
+
+    def test_render_calls_index_even_when_should_render_is_false(self):
+        """render() always calls index() — the should_render() guard is commented out."""
+        view = MagicMock(spec=[])  # should_render() would return False
+        viewlet = self._make_viewlet(view=view)
+        self.assertFalse(viewlet.should_render())
+        viewlet.index = MagicMock(return_value="output")
+        result = viewlet.render()
+        viewlet.index.assert_called_once()
+        self.assertEqual(result, "output")
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests (no Plone layer needed)
+# ---------------------------------------------------------------------------
+
+
+class TestBasePlugin(unittest.TestCase):
+    def test_contents_returns_empty_string(self):
+        plugin = BasePlugin()
+        self.assertEqual(plugin.contents, "")
+
+
+class TestPluginMatching(unittest.TestCase):
+    """Direct unit tests for each plugin's __call__ matching logic."""
+
+    def _call(self, plugin, url, config=None):
+        return plugin(urlparse(url), config or {})
+
+    # --- EaglebePlugin ---
+
+    def test_eaglebe_matches_eaglebe_url(self):
+        p = EaglebePlugin()
+        result = self._call(p, "https://app.eaglebe.com/auth/start", {"width": "100%"})
+        self.assertIs(result, p)
+
+    def test_eaglebe_returns_none_for_other_url(self):
+        p = EaglebePlugin()
+        self.assertIsNone(self._call(p, "https://kamoulox.be"))
+
+    # --- EllohaPlugin ---
+
+    def test_elloha_matches_elloha_url(self):
+        p = EllohaPlugin()
+        config = {"current_lang": "fr", "extra_params": None}
+        result = self._call(
+            p, "https://reservation.elloha.com/Scripts/widget-loader.min.js", config
+        )
+        self.assertIs(result, p)
+
+    def test_elloha_returns_none_for_other_url(self):
+        p = EllohaPlugin()
+        self.assertIsNone(self._call(p, "https://kamoulox.be"))
+
+    # --- CognitoformPlugin ---
+
+    def test_cognitoform_matches_cognitoforms_url(self):
+        p = CognitoformPlugin()
+        config = {"current_lang": "fr", "extra_params": None, "width": "100%"}
+        result = self._call(p, "https://www.cognitoforms.com/Org/Form", config)
+        self.assertIs(result, p)
+
+    def test_cognitoform_returns_none_for_other_url(self):
+        p = CognitoformPlugin()
+        self.assertIsNone(self._call(p, "https://kamoulox.be"))
+
+    # --- ArcgisPlugin ---
+
+    def test_arcgis_matches_arcgis_url(self):
+        p = ArcgisPlugin()
+        config = {
+            "current_lang": "fr",
+            "extra_params": None,
+            "url": "http://localhost",
+        }
+        result = self._call(p, "https://www.arcgis.com/apps/mapviewer/", config)
+        self.assertIs(result, p)
+
+    def test_arcgis_returns_none_for_other_url(self):
+        p = ArcgisPlugin()
+        self.assertIsNone(self._call(p, "https://kamoulox.be"))
+
+    # --- GiveADayPlugin ---
+
+    def test_giveaday_matches_giveaday_url(self):
+        p = GiveADayPlugin()
+        result = self._call(p, "https://www.giveaday.be/campaign/123")
+        self.assertIs(result, p)
+
+    def test_giveaday_returns_none_for_other_url(self):
+        p = GiveADayPlugin()
+        self.assertIsNone(self._call(p, "https://kamoulox.be"))
+
+    # --- IdeluxWastePlugin ---
+
+    def test_idelux_waste_matches_odwb_guide_de_tri_url(self):
+        p = IdeluxWastePlugin()
+        url = "https://www.odwb.be/api/explore/v2.1/catalog/datasets/guide-de-tri1/records"
+        result = self._call(p, url)
+        self.assertIs(result, p)
+
+    def test_idelux_waste_returns_none_for_non_matching_path(self):
+        p = IdeluxWastePlugin()
+        url = "https://www.odwb.be/api/explore/v2.1/catalog/datasets/other-dataset/records"
+        self.assertIsNone(self._call(p, url))
+
+    def test_idelux_waste_returns_none_for_non_odwb_host(self):
+        p = IdeluxWastePlugin()
+        self.assertIsNone(self._call(p, "https://kamoulox.be/guide-de-tri1"))
+
+    # --- InbwContainersAffluencePlugin ---
+
+    def test_inbw_affluence_matches_odwb_affluence_url(self):
+        p = InbwContainersAffluencePlugin()
+        url = "https://www.odwb.be/api/explore/v2.1/catalog/datasets/affluence/records"
+        result = self._call(p, url)
+        self.assertIs(result, p)
+
+    def test_inbw_affluence_returns_none_for_non_matching_path(self):
+        p = InbwContainersAffluencePlugin()
+        url = "https://www.odwb.be/api/explore/v2.1/catalog/datasets/other/records"
+        self.assertIsNone(self._call(p, url))
+
+    # --- OdwbWidgetPlugin ---
+
+    def test_odwb_widget_matches_opendatasoft_url(self):
+        p = OdwbWidgetPlugin()
+        config = {"extra_params": "<ods-dataset-context>...</ods-dataset-context>"}
+        result = self._call(
+            p, "https://static.opendatasoft.com/ods-widgets/my-widget", config
+        )
+        self.assertIs(result, p)
+
+    def test_odwb_widget_sets_is_odwb_widget_plugins_true_on_match(self):
+        p = OdwbWidgetPlugin()
+        config = {"extra_params": "html"}
+        self._call(p, "https://static.opendatasoft.com/ods-widgets/widget", config)
+        self.assertTrue(p.is_odwb_widget_plugins)
+
+    def test_odwb_widget_returns_none_for_other_url(self):
+        p = OdwbWidgetPlugin()
+        self.assertIsNone(self._call(p, "https://kamoulox.be"))
+
+    # --- UnknowServicePlugin ---
+
+    def test_unknow_service_always_returns_self(self):
+        p = UnknowServicePlugin()
+        result = self._call(p, "https://kamoulox.be", {"current_lang": "fr"})
+        self.assertIs(result, p)
+
+
+class TestTimeoutHandling(unittest.TestCase):
+    """Timeout exception branches in IdeluxWastePlugin and InbwContainersAffluencePlugin."""
+
+    def test_idelux_waste_contents_returns_none_on_timeout(self):
+        plugin = IdeluxWastePlugin()
+        url = "https://www.odwb.be/api/explore/v2.1/catalog/datasets/guide-de-tri1/records"
+        plugin.parts = urlparse(url)
+        plugin.url = url  # referenced in logger.warning inside except block
+        plugin.config = {}
+        with patch(f"{_VIEWS_MODULE}.requests.get") as mock_get:
+            mock_get.side_effect = requests.exceptions.Timeout
+            result = plugin.contents
+        self.assertIsNone(result)
+
+    def test_inbw_affluence_contents_returns_none_on_timeout(self):
+        plugin = InbwContainersAffluencePlugin()
+        url = "https://www.odwb.be/api/explore/v2.1/catalog/datasets/affluence/records"
+        plugin.parts = urlparse(url)
+        plugin.url = url  # referenced in logger.warning inside except block
+        plugin.config = {}
+        with patch(f"{_VIEWS_MODULE}.requests.get") as mock_get:
+            mock_get.side_effect = requests.exceptions.Timeout
+            result = plugin.contents
+        self.assertIsNone(result)
+
+
+class TestArcgisView(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+
+    def test_get_portal_item_id_reads_from_request(self):
+        self.request.portal_item_id = "27a432b0835149e6acd3ac39d0e4349c"
+        view = ArcgisView(self.portal, self.request)
+        self.assertEqual(view.get_portal_item_id, "27a432b0835149e6acd3ac39d0e4349c")
+
+
+class TestExternalContentViewExtra(ImioSmartwebTestCase):
+    layer = IMIO_SMARTWEB_CORE_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        self.page = api.content.create(
+            container=self.portal,
+            type="imio.smartweb.Page",
+            id="page",
+        )
+
+    def _make_section_view(self, url="https://kamoulox.be"):
+        sec = api.content.create(
+            container=self.page,
+            type="imio.smartweb.SectionExternalContent",
+            id="sec",
+        )
+        sec.external_content_url = url
+        return queryMultiAdapter((sec, self.request), name="view")
+
+    def test_has_leadimage_returns_true_when_context_has_image(self):
+        section_view = self._make_section_view()
+        with patch(f"{_VIEWS_MODULE}.ILeadImage") as mock_lead:
+            mock_lead.providedBy.return_value = True
+            section_view.context.image = object()  # any truthy value
+            result = section_view.has_leadimage()
+        self.assertTrue(result)
+
+    def test_render_viewlet_calls_index_and_returns_result(self):
+        section_view = self._make_section_view()
+        section_view.index = MagicMock(return_value="<div>section</div>")
+        result = section_view.render_viewlet()
+        section_view.index.assert_called_once()
+        self.assertEqual(result, "<div>section</div>")

--- a/src/imio/smartweb/core/tests/test_section_news.py
+++ b/src/imio/smartweb/core/tests/test_section_news.py
@@ -52,7 +52,7 @@ class TestSectionNews(ImioSmartwebTestCase):
         self.news.link_text = "Voir toutes les actualités"
         # Juste a patch to avoid "checking entity (get_json)" in case of missing NewsFolder in auth sources
         with patch(
-            "imio.smartweb.core.contents.sections.news.view.NewsView.get_news_folders_uids_and_title_from_entity",
+            "imio.smartweb.core.contents.sections.news.view.NewsView._get_news_folders_uids_and_title_from_entity",
             return_value=(
                 ["64f4cbee9a394a018a951f6d94452914"],
                 {"64f4cbee9a394a018a951f6d94452914": "News Folder title"},
@@ -65,7 +65,7 @@ class TestSectionNews(ImioSmartwebTestCase):
             )
             self.assertEqual(news_view.items, [])
 
-            url = "http://localhost:8080/Plone/@search?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
+            url = "http://localhost:8080/Plone/@search_newsitems?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
             m.get(url, text=json.dumps(self.json_news))
             self.assertEqual(news_view.items[0][0].get("title"), "Première actualité")
             self.assertEqual(len(news_view.items[0]), 3)
@@ -74,7 +74,7 @@ class TestSectionNews(ImioSmartwebTestCase):
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "bfe2b4391a0f4a8db6d8b7fed63d1c4a",
             ]
-            url = "http://localhost:8080/Plone/@search?UID=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&UID=bfe2b4391a0f4a8db6d8b7fed63d1c4a&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1"
+            url = "http://localhost:8080/Plone/@search_newsitems?UID=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&UID=bfe2b4391a0f4a8db6d8b7fed63d1c4a&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1"
             m.get(url, text=json.dumps(self.json_specific_news))
             self.assertEqual(len(news_view.items[0]), 2)
             self.assertEqual(
@@ -99,7 +99,7 @@ class TestSectionNews(ImioSmartwebTestCase):
         self.assertIsNone(annotations.get(SECTION_ITEMS_HASH_KEY))
         # Juste a patch to avoid "checking entity (get_json)" in case of missing NewsFolder in auth sources
         with patch(
-            "imio.smartweb.core.contents.sections.news.view.NewsView.get_news_folders_uids_and_title_from_entity",
+            "imio.smartweb.core.contents.sections.news.view.NewsView._get_news_folders_uids_and_title_from_entity",
             return_value=(
                 ["64f4cbee9a394a018a951f6d94452914"],
                 {"64f4cbee9a394a018a951f6d94452914": "News Folder title"},
@@ -108,7 +108,7 @@ class TestSectionNews(ImioSmartwebTestCase):
             news_view = queryMultiAdapter(
                 (self.news, self.request), name="carousel_view"
             )
-            url = "http://localhost:8080/Plone/@search?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
+            url = "http://localhost:8080/Plone/@search_newsitems?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
             m.get(url, text=json.dumps(self.json_news))
             self.assertEqual(len(news_view.items[0]), 3)
             hash_1 = annotations.get(SECTION_ITEMS_HASH_KEY)
@@ -116,7 +116,7 @@ class TestSectionNews(ImioSmartwebTestCase):
             first_modification = self.portalpage.ModificationDate()
 
             sleep(1)
-            url = "http://localhost:8080/Plone/@search?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
+            url = "http://localhost:8080/Plone/@search_newsitems?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
             m.get(url, text="{}")
             self.assertEqual(len(news_view.items), 0)
             next_modification = self.portalpage.ModificationDate()
@@ -132,7 +132,7 @@ class TestSectionNews(ImioSmartwebTestCase):
             self.assertEqual(next_modification, last_modification)
 
             sleep(1)
-            url = "http://localhost:8080/Plone/@search?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
+            url = "http://localhost:8080/Plone/@search_newsitems?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
             m.get(url, text=None)
             self.assertEqual(len(news_view.items), 0)
             no_modification = self.portalpage.ModificationDate()
@@ -147,7 +147,7 @@ class TestSectionNews(ImioSmartwebTestCase):
         self.news.linking_rest_view = RelationValue(intids.getId(self.rest_news_view))
         # Juste a patch to avoid "checking entity (get_json)" in case of missing NewsFolder in auth sources
         with patch(
-            "imio.smartweb.core.contents.sections.news.view.NewsView.get_news_folders_uids_and_title_from_entity",
+            "imio.smartweb.core.contents.sections.news.view.NewsView._get_news_folders_uids_and_title_from_entity",
             return_value=(
                 ["64f4cbee9a394a018a951f6d94452914"],
                 {"64f4cbee9a394a018a951f6d94452914": "News Folder title"},
@@ -156,7 +156,7 @@ class TestSectionNews(ImioSmartwebTestCase):
             news_view = queryMultiAdapter(
                 (self.news, self.request), name="carousel_view"
             )
-            url = "http://localhost:8080/Plone/@search?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
+            url = "http://localhost:8080/Plone/@search_newsitems?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
             m.get(url, text=json.dumps(self.json_news))
 
             self.assertIn("paysage_vignette", news_view.items[0][0]["image"])
@@ -170,7 +170,7 @@ class TestSectionNews(ImioSmartwebTestCase):
         self.news.linking_rest_view = RelationValue(intids.getId(self.rest_news_view))
         # Juste a patch to avoid "checking entity (get_json)" in case of missing NewsFolder in auth sources
         with patch(
-            "imio.smartweb.core.contents.sections.news.view.NewsView.get_news_folders_uids_and_title_from_entity",
+            "imio.smartweb.core.contents.sections.news.view.NewsView._get_news_folders_uids_and_title_from_entity",
             return_value=(
                 ["64f4cbee9a394a018a951f6d94452914"],
                 {"64f4cbee9a394a018a951f6d94452914": "News Folder title"},
@@ -179,7 +179,7 @@ class TestSectionNews(ImioSmartwebTestCase):
             news_view = queryMultiAdapter(
                 (self.news, self.request), name="carousel_view"
             )
-            url = "http://localhost:8080/Plone/@search?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
+            url = "http://localhost:8080/Plone/@search_newsitems?selected_news_folders=64f4cbee9a394a018a951f6d94452914&portal_type=imio.news.NewsItem&metadata_fields=container_uid&metadata_fields=category_title&metadata_fields=local_category&metadata_fields=topics&metadata_fields=has_leadimage&metadata_fields=modified&metadata_fields=effective&metadata_fields=UID&sort_limit=6&translated_in_en=1&sort_on=effective&sort_order=descending"
             m.get(url, text=json.dumps(self.json_news))
             self.assertEqual(news_view.items[0][0]["category"], "Presse")
             self.news.show_categories_or_topics = "category"


### PR DESCRIPTION
…incorrect/random? entity/newsfolders retrieval from cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable news retrieval for entities by using entity-aware folder resolution and avoiding incorrect cached results.

* **User Experience**
  * If a previously selected news folder is missing or renamed, the UI selects a sensible fallback (e.g., an administration folder) and shows a localized warning.

* **Tests**
  * Expanded test coverage for search, external content plugins, utilities, image handling, and related behaviors.

* **Changelog**
  * Changelog updated with the new entry for the unreleased release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->