### PR TITLE
feat(rest): add /ok health-check shortcut on request forwarders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.4.49 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- feat(rest): add /ok health-check shortcut on @directory/events/news_request_forwarder
+  endpoints (returns local {"status": "ok"} without forwarding to authentic source)
+  [bsuttor]
 
 
 1.4.48 (2026-06-08)

--- a/src/imio/smartweb/core/rest/authentic_sources.py
+++ b/src/imio/smartweb/core/rest/authentic_sources.py
@@ -32,6 +32,9 @@ class BaseRequestForwarder(Service):
         self.traversal_stack = []
 
     def reply(self):
+        if self.request.method == "GET" and self.traversal_stack == ["ok"]:
+            self.request.response.setStatus(200)
+            return {"status": "ok", "service": self.request_type}
         alsoProvides(self.request, IDisableCSRFProtection)
         url = "/".join(self.traversal_stack)
         if self.request_type == "events":

--- a/src/imio/smartweb/core/tests/test_rest.py
+++ b/src/imio/smartweb/core/tests/test_rest.py
@@ -730,6 +730,27 @@ class SectionsFunctionalTest(ImioSmartwebTestCase):
         )
 
     @patch("imio.smartweb.core.rest.authentic_sources.requests.request")
+    def test_request_forwarder_ok_shortcut(self, mock_request):
+        for endpoint, service_name in (
+            ("@directory_request_forwarder", "directory"),
+            ("@events_request_forwarder", "events"),
+            ("@news_request_forwarder", "news"),
+        ):
+            service = self.traverse(f"/plone/{endpoint}/ok")
+            response = service.reply()
+            self.assertEqual(response, {"status": "ok", "service": service_name})
+            self.assertEqual(self.request.response.status, 200)
+        mock_request.assert_not_called()
+
+        # Non-GET methods still forward
+        mock_request.return_value = FakeResponse(status_code=204)
+        service = self.traverse(
+            "/plone/@directory_request_forwarder/ok", method="POST"
+        )
+        service.reply()
+        mock_request.assert_called_once()
+
+    @patch("imio.smartweb.core.rest.authentic_sources.requests.request")
     @patch("imio.smartweb.core.rest.authentic_sources.get_default_view_url")
     def test_enrich_response(self, mock_view_url, mock_request):
         mock_view_url.return_value = "http://view-url"

--- a/src/imio/smartweb/core/tests/test_rest.py
+++ b/src/imio/smartweb/core/tests/test_rest.py
@@ -744,9 +744,7 @@ class SectionsFunctionalTest(ImioSmartwebTestCase):
 
         # Non-GET methods still forward
         mock_request.return_value = FakeResponse(status_code=204)
-        service = self.traverse(
-            "/plone/@directory_request_forwarder/ok", method="POST"
-        )
+        service = self.traverse("/plone/@directory_request_forwarder/ok", method="POST")
         service.reply()
         mock_request.assert_called_once()
 


### PR DESCRIPTION
  Intercept GET @{directory,events,news}_request_forwarder/ok in
  BaseRequestForwarder.reply() and return {"status": "ok", "service": <name>}
  locally, without contacting the authentic source. Lets us verify the
  Plone-side forwarder endpoint is reachable independently of upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `/ok` health-check shortcut on request forwarders: GET /.../ok returns a local JSON status response immediately; non-GET requests continue to be forwarded normally.
* **Tests**
  * Added tests covering the `/ok` shortcut to ensure GET returns the local status without contacting upstream and POSTs are forwarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->