### PR TITLE
fix(rest): make /ok health-check shortcut reachable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.4.50 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- fix(rest): make /ok health-check shortcut reachable with Accept: */*
+  (e.g. passerelle check_status that bypasses its JSON request wrapper)
+  [bsuttor]
 
 
 1.4.49 (2026-06-08)

--- a/src/imio/smartweb/core/rest/configure.zcml
+++ b/src/imio/smartweb/core/rest/configure.zcml
@@ -14,6 +14,15 @@
       />
 
   <plone:service
+      method="GET"
+      accept="*/*"
+      factory=".authentic_sources.DirectoryRequestForwarder"
+      for="*"
+      permission="zope2.View"
+      name="@directory_request_forwarder"
+      />
+
+  <plone:service
       method="POST"
       accept="application/json"
       factory=".authentic_sources.DirectoryRequestForwarder"
@@ -52,6 +61,15 @@
       />
 
   <plone:service
+      method="GET"
+      accept="*/*"
+      factory=".authentic_sources.EventsRequestForwarder"
+      for="*"
+      permission="zope2.View"
+      name="@events_request_forwarder"
+      />
+
+  <plone:service
       method="POST"
       accept="application/json"
       factory=".authentic_sources.EventsRequestForwarder"
@@ -83,6 +101,15 @@
   <plone:service
       method="GET"
       accept="application/json"
+      factory=".authentic_sources.NewsRequestForwarder"
+      for="*"
+      permission="zope2.View"
+      name="@news_request_forwarder"
+      />
+
+  <plone:service
+      method="GET"
+      accept="*/*"
       factory=".authentic_sources.NewsRequestForwarder"
       for="*"
       permission="zope2.View"

--- a/src/imio/smartweb/core/tests/test_rest.py
+++ b/src/imio/smartweb/core/tests/test_rest.py
@@ -748,6 +748,21 @@ class SectionsFunctionalTest(ImioSmartwebTestCase):
         service.reply()
         mock_request.assert_called_once()
 
+    def test_request_forwarder_ok_without_json_accept(self):
+        # passerelle's check_status sends `Accept: */*` (no application/json),
+        # so the endpoint must be registered for that media type too.
+        for endpoint, service_name in (
+            ("@directory_request_forwarder", "directory"),
+            ("@events_request_forwarder", "events"),
+            ("@news_request_forwarder", "news"),
+        ):
+            session = RelativeSession(self.portal_url)
+            session.headers.pop("Accept", None)
+            resp = session.get(f"/{endpoint}/ok")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json(), {"status": "ok", "service": service_name})
+            session.close()
+
     @patch("imio.smartweb.core.rest.authentic_sources.requests.request")
     @patch("imio.smartweb.core.rest.authentic_sources.get_default_view_url")
     def test_enrich_response(self, mock_view_url, mock_request):


### PR DESCRIPTION
ref: KEYC-77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed health-check endpoints (`/ok`) for directory, events, and news services to be reachable with any Accept header format, improving compatibility with external monitoring tools.

* **Tests**
  * Added functional tests verifying health-check endpoints respond correctly with various Accept header configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->