### PR TITLE
feat: get SSO-APPS credentials instead of authentic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.4.52 (unreleased)
 -------------------
 
+- WEB-4448 : Get SSO-APPS credentials instead of authentic
+  [boulch, remdub]
+
 - Move ``imio.smartweb.vocabulary.RemoteDirectoryEntities`` vocabulary to imio.smartweb.common (1.2.55)
   [boulch]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,12 +58,12 @@ Content types that display remote data from sibling iMio apps:
 
 | Type | Authentic source | Env vars |
 |------|-----------------|----------|
-| `DirectoryView` | imio.directory | `DIRECTORY_URL`, `RESTAPI_DIRECTORY_CLIENT_ID/SECRET` |
-| `EventsView` | imio.events | `EVENTS_URL`, `RESTAPI_EVENTS_CLIENT_ID/SECRET` |
-| `NewsView` | imio.news | `NEWS_URL`, `RESTAPI_NEWS_CLIENT_ID/SECRET` |
+| `DirectoryView` | imio.directory | `DIRECTORY_URL` |
+| `EventsView` | imio.events | `EVENTS_URL` |
+| `NewsView` | imio.news | `NEWS_URL` |
 | `CampaignView` | WCS ideabox | (WCS config) |
 
-Request forwarders in `rest/authentic_sources.py` proxy HTTP to remote APIs with OAuth token auth.
+Request forwarders in `rest/authentic_sources.py` proxy HTTP to remote APIs. Auth uses a Bearer token forwarded from `request._auth`; SSO-APPS credentials (`SSO_APPS_CLIENT_ID` / `SSO_APPS_CLIENT_SECRET`) are used to obtain WCA tokens for vocabulary/metadata fetching (see `vocabularies.py`, `contents/rest/utils.py`).
 
 ### Behaviors (`behaviors/`)
 

--- a/src/imio/smartweb/core/contents/rest/utils.py
+++ b/src/imio/smartweb/core/contents/rest/utils.py
@@ -38,18 +38,12 @@ def get_auth_sources_response(
     if sources_name == "directory":
         url = DIRECTORY_URL
         portaltype = "imio.directory.Contact"
-        client_id_varname = "RESTAPI_DIRECTORY_CLIENT_ID"
-        client_secret_varname = "RESTAPI_DIRECTORY_CLIENT_SECRET"
     elif sources_name == "events":
         url = EVENTS_URL
         portaltype = "imio.events.Event"
-        client_id_varname = "RESTAPI_EVENTS_CLIENT_ID"
-        client_secret_varname = "RESTAPI_EVENTS_CLIENT_SECRET"
     elif sources_name == "news":
         url = NEWS_URL
         portaltype = "imio.news.NewsItem"
-        client_id_varname = "RESTAPI_NEWS_CLIENT_ID"
-        client_secret_varname = "RESTAPI_NEWS_CLIENT_SECRET"
 
     payload = {
         "query": [
@@ -76,8 +70,8 @@ def get_auth_sources_response(
         "b_start": 0,
         "b_size": 4000,
     }
-    client_id = os.environ.get(client_id_varname)
-    client_secret = os.environ.get(client_secret_varname)
+    client_id = os.environ.get("SSO_APPS_CLIENT_ID", "imio-apps-smartweb")
+    client_secret = os.environ.get("SSO_APPS_CLIENT_SECRET", "")
     auth = get_wca_token(client_id, client_secret)
     headers = {
         "Accept": "application/json",

--- a/src/imio/smartweb/core/rest/authentic_sources.py
+++ b/src/imio/smartweb/core/rest/authentic_sources.py
@@ -17,7 +17,6 @@ from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 
 import logging
-import os
 import requests
 
 _BRUSSELS_TZ = ZoneInfo("Europe/Brussels")
@@ -154,8 +153,6 @@ class BaseRequestForwarder(Service):
 
 class DirectoryRequestForwarder(BaseRequestForwarder):
     request_type = "directory"
-    client_id = os.environ.get("RESTAPI_DIRECTORY_CLIENT_ID")
-    client_secret = os.environ.get("RESTAPI_DIRECTORY_CLIENT_SECRET")
     base_url = DIRECTORY_URL
 
     def enrich_response(self, response):
@@ -164,8 +161,6 @@ class DirectoryRequestForwarder(BaseRequestForwarder):
 
 class EventsRequestForwarder(BaseRequestForwarder):
     request_type = "events"
-    client_id = os.environ.get("RESTAPI_EVENTS_CLIENT_ID")
-    client_secret = os.environ.get("RESTAPI_EVENTS_CLIENT_SECRET")
     base_url = EVENTS_URL
 
     _DATE_FORMATS = (
@@ -199,8 +194,6 @@ class EventsRequestForwarder(BaseRequestForwarder):
 
 class NewsRequestForwarder(BaseRequestForwarder):
     request_type = "news"
-    client_id = os.environ.get("RESTAPI_NEWS_CLIENT_ID")
-    client_secret = os.environ.get("RESTAPI_NEWS_CLIENT_SECRET")
     base_url = NEWS_URL
 
     def enrich_response(self, response):

--- a/src/imio/smartweb/core/utils.py
+++ b/src/imio/smartweb/core/utils.py
@@ -79,8 +79,8 @@ def get_json(url, auth=None, timeout=5):
 
 
 def get_wca_token(client_id, client_secret):
-    username = os.environ.get("RESTAPI_USER_USERNAME")
-    password = os.environ.get("RESTAPI_USER_PASSWORD")
+    username = os.environ.get("SSO_APPS_USER_USERNAME", "imio-apps-smartweb_belleville-ac")
+    password = os.environ.get("SSO_APPS_USER_PASSWORD", "")
 
     payload = {
         "grant_type": "password",

--- a/src/imio/smartweb/core/utils.py
+++ b/src/imio/smartweb/core/utils.py
@@ -79,7 +79,9 @@ def get_json(url, auth=None, timeout=5):
 
 
 def get_wca_token(client_id, client_secret):
-    username = os.environ.get("SSO_APPS_USER_USERNAME", "imio-apps-smartweb_belleville-ac")
+    username = os.environ.get(
+        "SSO_APPS_USER_USERNAME", "imio-apps-smartweb_belleville-ac"
+    )
     password = os.environ.get("SSO_APPS_USER_PASSWORD", "")
 
     payload = {

--- a/src/imio/smartweb/core/vocabularies.py
+++ b/src/imio/smartweb/core/vocabularies.py
@@ -562,8 +562,8 @@ FilteredCategoryAndTopicsVocabulary = FilteredCategoryAndTopicsVocabularyFactory
 
 class DirectoryCategoriesVocabularyFactory:
     def __call__(self, context=None):
-        client_id = os.environ.get("RESTAPI_DIRECTORY_CLIENT_ID")
-        client_secret = os.environ.get("RESTAPI_DIRECTORY_CLIENT_SECRET")
+        client_id = os.environ.get("SSO_APPS_CLIENT_ID", "imio-apps-smartweb")
+        client_secret = os.environ.get("SSO_APPS_CLIENT_SECRET", "")
         auth = get_wca_token(client_id, client_secret)
         url = f"{DIRECTORY_URL}/@vocabularies/collective.taxonomy.contact_category?b_size=1000000"
         categories_json = get_json(url, auth=auth)
@@ -585,8 +585,8 @@ DirectoryCategoriesVocabulary = DirectoryCategoriesVocabularyFactory()
 class EventsTypesVocabularyFactory:
     @ram.cache(lambda *args: time() // (60 * 60))
     def __call__(self, context=None):
-        client_id = os.environ.get("RESTAPI_EVENTS_CLIENT_ID")
-        client_secret = os.environ.get("RESTAPI_EVENTS_CLIENT_SECRET")
+        client_id = os.environ.get("SSO_APPS_CLIENT_ID", "imio-apps-smartweb")
+        client_secret = os.environ.get("SSO_APPS_CLIENT_SECRET", "")
         auth = get_wca_token(client_id, client_secret)
         url = f"{EVENTS_URL}/@vocabularies/imio.events.vocabulary.EventTypes"
         eventstypes_json = get_json(url, auth=auth)


### PR DESCRIPTION
WEB-4448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated REST directory, events, and news authentication to consistently use unified SSO-APPS credentials.
  * Token requests now read WCA credentials from SSO-APPS username/password environment variables where applicable.
* **Documentation**
  * Updated the changelog entry (WEB-4448) and refreshed documentation to reflect the new environment variable usage for REST views and token forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->